### PR TITLE
Improving tests

### DIFF
--- a/tapi/utils/testing_decorators.py
+++ b/tapi/utils/testing_decorators.py
@@ -1,4 +1,4 @@
-from os import getenv
+from os       import getenv
 from unittest import skipIf
 
 def premium_test(func):

--- a/tapi/utils/testing_decorators.py
+++ b/tapi/utils/testing_decorators.py
@@ -1,5 +1,5 @@
 from os       import getenv
 from unittest import skipIf
 
-def premium_test(func):
+def premium_feature(func):
     return skipIf(getenv("SKIP_PREMIUM_TESTS") == "1", "Skipping premium test")(func)

--- a/tapi/utils/testing_decorators.py
+++ b/tapi/utils/testing_decorators.py
@@ -1,0 +1,5 @@
+from os import getenv
+from unittest import skipIf
+
+def premium_test(func):
+    return skipIf(getenv("SKIP_PREMIUM_TESTS") == "1", "Skipping premium test")(func)

--- a/tests/test_api/test_action/test_actions.py
+++ b/tests/test_api/test_action/test_actions.py
@@ -4,10 +4,16 @@ from time             import time_ns
 from tapi.utils.types import AgentType
 from tapi             import ActionsAPI
 from dotenv           import load_dotenv
+from tapi.utils.http  import disable_ssl_verification
+
 
 class test_ActionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.story_id    = int(getenv("ACTION_STORY_ID"))
         self.action_id   = int(getenv("ACTION_ID"))
         self.actions_api = ActionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -43,8 +49,6 @@ class test_ActionsAPI(unittest.TestCase):
 
     def test_update(self):
         rng = time_ns() // 1000
-
-
         resp = self.actions_api.update(
             action_id   = self.action_id,
             description = f"Updated description: {rng}"

--- a/tests/test_api/test_action/test_events.py
+++ b/tests/test_api/test_action/test_events.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ActionEventsAPI
+from os              import getenv
+from dotenv          import load_dotenv
+from tapi            import ActionEventsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_ActionEventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.action_id   = int(getenv("ACTION_ID"))
         self.action_events_api = ActionEventsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_action/test_logs.py
+++ b/tests/test_api/test_action/test_logs.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ActionLogsAPI
+from os              import getenv
+from dotenv          import load_dotenv
+from tapi            import ActionLogsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_ActionLogsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.action_id   = int(getenv("ACTION_ID"))
         self.action_logs_api = ActionLogsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_audit_log/test_audit_logs.py
+++ b/tests/test_api/test_audit_log/test_audit_logs.py
@@ -1,9 +1,9 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi             import AuditLogsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import AuditLogsAPI
 from tapi.utils.testing_decorators import premium_test
-from tapi.utils.types import AuditLogType
+from tapi.utils.types              import AuditLogType
 
 class test_AuditLogsAPI(unittest.TestCase):
     def setUp(self):

--- a/tests/test_api/test_audit_log/test_audit_logs.py
+++ b/tests/test_api/test_audit_log/test_audit_logs.py
@@ -2,6 +2,7 @@ import unittest
 from os               import getenv
 from dotenv           import load_dotenv
 from tapi             import AuditLogsAPI
+from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types import AuditLogType
 
 class test_AuditLogsAPI(unittest.TestCase):
@@ -9,6 +10,7 @@ class test_AuditLogsAPI(unittest.TestCase):
         load_dotenv()
         self.audt_logs_api = AuditLogsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_list(self):
         resp = self.audt_logs_api.list(
             operation_name = [

--- a/tests/test_api/test_audit_log/test_audit_logs.py
+++ b/tests/test_api/test_audit_log/test_audit_logs.py
@@ -2,15 +2,20 @@ import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
 from tapi                          import AuditLogsAPI
-from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types              import AuditLogType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 class test_AuditLogsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.audt_logs_api = AuditLogsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.audt_logs_api.list(
             operation_name = [

--- a/tests/test_api/test_case/test_actions.py
+++ b/tests/test_api/test_case/test_actions.py
@@ -1,9 +1,9 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi             import CaseActionsAPI
-from tapi.utils.types import CaseActionType
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseActionsAPI
+from tapi.utils.types              import CaseActionType
 
 
 

--- a/tests/test_api/test_case/test_actions.py
+++ b/tests/test_api/test_case/test_actions.py
@@ -3,6 +3,8 @@ from os               import getenv
 from dotenv           import load_dotenv
 from tapi             import CaseActionsAPI
 from tapi.utils.types import CaseActionType
+from tapi.utils.testing_decorators import premium_test
+
 
 
 class test_CaseActionsAPI(unittest.TestCase):
@@ -19,6 +21,7 @@ class test_CaseActionsAPI(unittest.TestCase):
                 id      = self.action_id
             )
 
+    @premium_test
     def test_create(self):
         resp = self.case_action_api.create(
             case_id     = self.case_id,
@@ -36,6 +39,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
+    @premium_test
     def test_get(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -60,6 +64,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
+    @premium_test
     def test_update(self):
         action = self.case_action_api.create(
             case_id=self.case_id,
@@ -85,6 +90,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("label"), "New Updated Action Unit Test")
         self.assertEqual(body.get("action_text"), "GoTo")
 
+    @premium_test
     def test_list(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -106,6 +112,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(type(body.get("actions")), list)
         self.assertGreaterEqual(len(body.get("actions")), 1)
 
+    @premium_test
     def test_delete(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -124,6 +131,7 @@ class test_CaseActionsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_test
     def tests_batch_update(self):
         actions = [
             {

--- a/tests/test_api/test_case/test_actions.py
+++ b/tests/test_api/test_case/test_actions.py
@@ -1,15 +1,20 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseActionsAPI
 from tapi.utils.types              import CaseActionType
+from tapi.utils.http               import disable_ssl_verification
 
 
 
 class test_CaseActionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.action_id       = None
         self.case_action_api = CaseActionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -21,7 +26,7 @@ class test_CaseActionsAPI(unittest.TestCase):
                 id      = self.action_id
             )
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_action_api.create(
             case_id     = self.case_id,
@@ -39,7 +44,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -64,7 +69,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         action = self.case_action_api.create(
             case_id=self.case_id,
@@ -90,7 +95,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("label"), "New Updated Action Unit Test")
         self.assertEqual(body.get("action_text"), "GoTo")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -112,7 +117,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(type(body.get("actions")), list)
         self.assertGreaterEqual(len(body.get("actions")), 1)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -131,7 +136,7 @@ class test_CaseActionsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
-    @premium_test
+    @premium_feature
     def tests_batch_update(self):
         actions = [
             {

--- a/tests/test_api/test_case/test_activities.py
+++ b/tests/test_api/test_case/test_activities.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import CaseActivitiesAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseActivitiesAPI(unittest.TestCase):
@@ -10,6 +11,7 @@ class test_CaseActivitiesAPI(unittest.TestCase):
         self.case_id         = int(getenv("CASE_ID"))
         self.case_activities_api = CaseActivitiesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_get(self):
         resp = self.case_activities_api.get(
             case_id = self.case_id,
@@ -18,6 +20,7 @@ class test_CaseActivitiesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
+    @premium_test
     def test_list(self):
         resp = self.case_activities_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_activities.py
+++ b/tests/test_api/test_case/test_activities.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseActivitiesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseActivitiesAPI
 
 
 class test_CaseActivitiesAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_activities.py
+++ b/tests/test_api/test_case/test_activities.py
@@ -1,17 +1,22 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseActivitiesAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseActivitiesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.case_activities_api = CaseActivitiesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_activities_api.get(
             case_id = self.case_id,
@@ -20,7 +25,7 @@ class test_CaseActivitiesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_activities_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_assignees.py
+++ b/tests/test_api/test_case/test_assignees.py
@@ -1,17 +1,22 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseAssigneesAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseAssigneesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id            = int(getenv("CASE_ID"))
         self.case_assignees_api = CaseAssigneesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_assignees_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_assignees.py
+++ b/tests/test_api/test_case/test_assignees.py
@@ -1,7 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseAssigneesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseAssigneesAPI
 
 
 class test_CaseAssigneesAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_assignees.py
+++ b/tests/test_api/test_case/test_assignees.py
@@ -10,6 +10,7 @@ class test_CaseAssigneesAPI(unittest.TestCase):
         self.case_id            = int(getenv("CASE_ID"))
         self.case_assignees_api = CaseAssigneesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_list(self):
         resp = self.case_assignees_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_cases.py
+++ b/tests/test_api/test_case/test_cases.py
@@ -1,9 +1,9 @@
 import unittest
-from os               import getenv
-from tapi             import CaseAPI
-from dotenv           import load_dotenv
-from tapi.utils.types import CasePriority, CaseStatus
+from os                            import getenv
+from tapi                          import CaseAPI
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi.utils.types              import CasePriority, CaseStatus
 
 
 class test_CasesAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_cases.py
+++ b/tests/test_api/test_case/test_cases.py
@@ -2,13 +2,18 @@ import unittest
 from os                            import getenv
 from tapi                          import CaseAPI
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 from tapi.utils.types              import CasePriority, CaseStatus
 
 
 class test_CasesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id   = 1 #int(getenv("TEAM_ID"))
         self.case_id   = None
         self.cases_api = CaseAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -17,7 +22,7 @@ class test_CasesAPI(unittest.TestCase):
         if self.case_id:
             self.cases_api.delete(self.case_id)
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.cases_api.create(
             team_id     = self.team_id,
@@ -34,7 +39,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("status"), CaseStatus.OPEN)
         self.assertEqual(body.get("priority"), CasePriority.LOW)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -55,7 +60,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("name"), "Get Case Unit test")
         self.assertEqual(body.get("description"), "Created with Tapi :)")
 
-    @premium_test
+    @premium_feature
     def test_download(self):
         resp = self.cases_api.download(
             case_id = 26
@@ -66,7 +71,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body), bytes)
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -89,7 +94,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("description"), "Created with Tapi :) :)")
         self.assertEqual(body.get("priority"), CasePriority.HIGH)
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -108,7 +113,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertGreaterEqual(len(body.get("cases")), 1)
         self.assertLessEqual(len(body.get("cases")), 5)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         case = self.cases_api.create(
             team_id     = self.team_id,

--- a/tests/test_api/test_case/test_cases.py
+++ b/tests/test_api/test_case/test_cases.py
@@ -3,12 +3,13 @@ from os               import getenv
 from tapi             import CaseAPI
 from dotenv           import load_dotenv
 from tapi.utils.types import CasePriority, CaseStatus
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CasesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
-        self.team_id   = int(getenv("TEAM_ID"))
+        self.team_id   = 1 #int(getenv("TEAM_ID"))
         self.case_id   = None
         self.cases_api = CaseAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
@@ -16,6 +17,7 @@ class test_CasesAPI(unittest.TestCase):
         if self.case_id:
             self.cases_api.delete(self.case_id)
 
+    @premium_test
     def test_create(self):
         resp = self.cases_api.create(
             team_id     = self.team_id,
@@ -32,6 +34,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("status"), CaseStatus.OPEN)
         self.assertEqual(body.get("priority"), CasePriority.LOW)
 
+    @premium_test
     def test_get(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -52,6 +55,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("name"), "Get Case Unit test")
         self.assertEqual(body.get("description"), "Created with Tapi :)")
 
+    @premium_test
     def test_download(self):
         resp = self.cases_api.download(
             case_id = 26
@@ -62,6 +66,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body), bytes)
 
+    @premium_test
     def test_update(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -84,6 +89,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("description"), "Created with Tapi :) :)")
         self.assertEqual(body.get("priority"), CasePriority.HIGH)
 
+    @premium_test
     def test_list(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -102,6 +108,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertGreaterEqual(len(body.get("cases")), 1)
         self.assertLessEqual(len(body.get("cases")), 5)
 
+    @premium_test
     def test_delete(self):
         case = self.cases_api.create(
             team_id     = self.team_id,

--- a/tests/test_api/test_case/test_comments.py
+++ b/tests/test_api/test_case/test_comments.py
@@ -1,9 +1,9 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi.utils.types import ReactionType
-from tapi             import CaseCommentsAPI, CaseCommentsReactionsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi.utils.types              import ReactionType
+from tapi                          import CaseCommentsAPI, CaseCommentsReactionsAPI
 
 
 class test_CaseCommentsAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_comments.py
+++ b/tests/test_api/test_case/test_comments.py
@@ -3,6 +3,7 @@ from os               import getenv
 from dotenv           import load_dotenv
 from tapi.utils.types import ReactionType
 from tapi             import CaseCommentsAPI, CaseCommentsReactionsAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseCommentsAPI(unittest.TestCase):
@@ -11,6 +12,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.case_id           = int(getenv("CASE_ID"))
         self.case_comments_api = CaseCommentsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.case_comments_api.create(
             case_id = self.case_id,
@@ -19,6 +21,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_test
     def test_get(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -38,6 +41,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "Get Comment Unit Test")
 
+    @premium_test
     def test_update(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -58,6 +62,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "New Updated Comment Unit Test")
 
+    @premium_test
     def test_list(self):
         resp = self.case_comments_api.list(
             case_id = self.case_id
@@ -68,6 +73,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("comments")), list)
 
+    @premium_test
     def test_delete(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -89,6 +95,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.case_id                     = int(getenv("CASE_ID"))
         self.case_comments_reactions_api = CaseCommentsReactionsAPI(getenv("DOMAIN"), getenv("API_KEY_2"))
 
+    @premium_test
     def test_add(self):
         resp = self.case_comments_reactions_api.add(
             case_id    = self.case_id,
@@ -101,6 +108,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(type(body.get("reactions")), list)
 
+    @premium_test
     def test_remove(self):
         reaction = self.case_comments_reactions_api.add(
             case_id=self.case_id,

--- a/tests/test_api/test_case/test_comments.py
+++ b/tests/test_api/test_case/test_comments.py
@@ -1,18 +1,23 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types              import ReactionType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 from tapi                          import CaseCommentsAPI, CaseCommentsReactionsAPI
 
 
 class test_CaseCommentsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_comments_api = CaseCommentsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_comments_api.create(
             case_id = self.case_id,
@@ -21,7 +26,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -41,7 +46,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "Get Comment Unit Test")
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -62,7 +67,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "New Updated Comment Unit Test")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_comments_api.list(
             case_id = self.case_id
@@ -73,7 +78,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("comments")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -95,7 +100,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.case_id                     = int(getenv("CASE_ID"))
         self.case_comments_reactions_api = CaseCommentsReactionsAPI(getenv("DOMAIN"), getenv("API_KEY_2"))
 
-    @premium_test
+    @premium_feature
     def test_add(self):
         resp = self.case_comments_reactions_api.add(
             case_id    = self.case_id,
@@ -108,7 +113,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(type(body.get("reactions")), list)
 
-    @premium_test
+    @premium_feature
     def test_remove(self):
         reaction = self.case_comments_reactions_api.add(
             case_id=self.case_id,

--- a/tests/test_api/test_case/test_fields.py
+++ b/tests/test_api/test_case/test_fields.py
@@ -1,18 +1,23 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseFieldsAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFieldsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.input_id        = int(getenv("CASE_INPUT_ID"))
         self.case_fields_api = CaseFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_fields_api.create(
             case_id  = self.case_id,
@@ -25,7 +30,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(body.get("field").get("value"), "1")
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_fields_api.get(
             case_id  = self.case_id,
@@ -38,7 +43,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(body.get("case_id"), self.case_id)
         self.assertEqual(body.get("field").get("id"), int(getenv("CASE_FIELD_ID")))
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         resp = self.case_fields_api.update(
             case_id  = self.case_id,
@@ -51,7 +56,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("field").get("value"), "2")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_fields_api.list(
             case_id = self.case_id
@@ -62,7 +67,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("fields")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         field = self.case_fields_api.create(
             case_id  = self.case_id,

--- a/tests/test_api/test_case/test_fields.py
+++ b/tests/test_api/test_case/test_fields.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseFieldsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseFieldsAPI
 
 
 class test_CaseFieldsAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_fields.py
+++ b/tests/test_api/test_case/test_fields.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import CaseFieldsAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseFieldsAPI(unittest.TestCase):
@@ -11,6 +12,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.input_id        = int(getenv("CASE_INPUT_ID"))
         self.case_fields_api = CaseFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.case_fields_api.create(
             case_id  = self.case_id,
@@ -23,6 +25,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(body.get("field").get("value"), "1")
 
+    @premium_test
     def test_get(self):
         resp = self.case_fields_api.get(
             case_id  = self.case_id,
@@ -35,6 +38,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(body.get("case_id"), self.case_id)
         self.assertEqual(body.get("field").get("id"), int(getenv("CASE_FIELD_ID")))
 
+    @premium_test
     def test_update(self):
         resp = self.case_fields_api.update(
             case_id  = self.case_id,
@@ -47,6 +51,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("field").get("value"), "2")
 
+    @premium_test
     def test_list(self):
         resp = self.case_fields_api.list(
             case_id = self.case_id
@@ -57,6 +62,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("fields")), list)
 
+    @premium_test
     def test_delete(self):
         field = self.case_fields_api.create(
             case_id  = self.case_id,

--- a/tests/test_api/test_case/test_files.py
+++ b/tests/test_api/test_case/test_files.py
@@ -2,16 +2,21 @@ import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
 from tapi                          import CaseFilesAPI
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id        = int(getenv("CASE_ID"))
         self.case_files_api = CaseFilesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_files_api.create(
             case_id       = self.case_id,
@@ -27,7 +32,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test.txt")
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_files_api.get(
             case_id = self.case_id,
@@ -42,7 +47,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_files_api.list(
             case_id=self.case_id
@@ -53,7 +58,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("files")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         file = self.case_files_api.create(
             case_id       = self.case_id,
@@ -71,7 +76,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
-    # @premium_test
+    # @premium_feature
     # Endpoint need to be fixed by Tines, first
     # def test_download(self):
     #     resp = self.case_files_api.download(

--- a/tests/test_api/test_case/test_files.py
+++ b/tests/test_api/test_case/test_files.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import CaseFilesAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseFilesAPI(unittest.TestCase):
@@ -10,6 +11,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.case_id        = int(getenv("CASE_ID"))
         self.case_files_api = CaseFilesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.case_files_api.create(
             case_id       = self.case_id,
@@ -25,6 +27,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test.txt")
 
+    @premium_test
     def test_get(self):
         resp = self.case_files_api.get(
             case_id = self.case_id,
@@ -39,6 +42,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test")
 
+    @premium_test
     def test_list(self):
         resp = self.case_files_api.list(
             case_id=self.case_id
@@ -49,6 +53,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("files")), list)
 
+    @premium_test
     def test_delete(self):
         file = self.case_files_api.create(
             case_id       = self.case_id,
@@ -66,6 +71,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    # @premium_test
     # Endpoint need to be fixed by Tines, first
     # def test_download(self):
     #     resp = self.case_files_api.download(

--- a/tests/test_api/test_case/test_files.py
+++ b/tests/test_api/test_case/test_files.py
@@ -1,7 +1,7 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseFilesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import CaseFilesAPI
 from tapi.utils.testing_decorators import premium_test
 
 

--- a/tests/test_api/test_case/test_inputs.py
+++ b/tests/test_api/test_case/test_inputs.py
@@ -1,11 +1,10 @@
 import unittest
-from os               import getenv
-from time             import time_ns
-from dotenv           import load_dotenv
-
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
-from tapi.utils.types import CaseInputType
-from tapi             import CaseInputsAPI, CaseInputsFieldsAPI
+from tapi.utils.types              import CaseInputType
+from tapi                          import CaseInputsAPI, CaseInputsFieldsAPI
 
 
 class test_CaseInputsAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_inputs.py
+++ b/tests/test_api/test_case/test_inputs.py
@@ -2,18 +2,23 @@ import unittest
 from os                            import getenv
 from time                          import time_ns
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types              import CaseInputType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 from tapi                          import CaseInputsAPI, CaseInputsFieldsAPI
 
 
 class test_CaseInputsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id         = int(getenv("TEAM_ID"))
         self.case_inputs_api = CaseInputsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         input_id = time_ns() // 1000
         resp = self.case_inputs_api.create(
@@ -27,7 +32,7 @@ class test_CaseInputsAPI(unittest.TestCase):
         self.assertEqual(body.get("team_case_input").get("name"), f"Create Case Input Unit Test {input_id}")
         self.assertEqual(body.get("team_case_input").get("input_type"), CaseInputType.NUMBER)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_inputs_api.get(
             case_input_id = int(getenv("CASE_INPUT_ID"))
@@ -35,7 +40,7 @@ class test_CaseInputsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_inputs_api.list(
             team_id = self.team_id
@@ -51,7 +56,7 @@ class test_CaseInputsFieldsAPI(unittest.TestCase):
         load_dotenv()
         self.case_inputs_fields_api = CaseInputsFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_inputs_fields_api.list(
             case_input_id = int(getenv("CASE_INPUT_ID"))

--- a/tests/test_api/test_case/test_inputs.py
+++ b/tests/test_api/test_case/test_inputs.py
@@ -2,6 +2,8 @@ import unittest
 from os               import getenv
 from time             import time_ns
 from dotenv           import load_dotenv
+
+from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types import CaseInputType
 from tapi             import CaseInputsAPI, CaseInputsFieldsAPI
 
@@ -12,6 +14,7 @@ class test_CaseInputsAPI(unittest.TestCase):
         self.team_id         = int(getenv("TEAM_ID"))
         self.case_inputs_api = CaseInputsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         input_id = time_ns() // 1000
         resp = self.case_inputs_api.create(
@@ -25,6 +28,7 @@ class test_CaseInputsAPI(unittest.TestCase):
         self.assertEqual(body.get("team_case_input").get("name"), f"Create Case Input Unit Test {input_id}")
         self.assertEqual(body.get("team_case_input").get("input_type"), CaseInputType.NUMBER)
 
+    @premium_test
     def test_get(self):
         resp = self.case_inputs_api.get(
             case_input_id = int(getenv("CASE_INPUT_ID"))
@@ -32,6 +36,7 @@ class test_CaseInputsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
+    @premium_test
     def test_list(self):
         resp = self.case_inputs_api.list(
             team_id = self.team_id
@@ -47,6 +52,7 @@ class test_CaseInputsFieldsAPI(unittest.TestCase):
         load_dotenv()
         self.case_inputs_fields_api = CaseInputsFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_list(self):
         resp = self.case_inputs_fields_api.list(
             case_input_id = int(getenv("CASE_INPUT_ID"))

--- a/tests/test_api/test_case/test_linked_cases.py
+++ b/tests/test_api/test_case/test_linked_cases.py
@@ -1,19 +1,24 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
 from tapi                          import LinkedCasesAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_LinkedCasesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_to_link_id_1 = int(getenv("CASE_TO_LINK_ID_1"))
         self.case_to_link_id_2 = int(getenv("CASE_TO_LINK_ID_2"))
         self.linked_cases_api = LinkedCasesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.linked_cases_api.create(
             case_id = self.case_id,
@@ -22,7 +27,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.linked_cases_api.list(
             case_id = self.case_id
@@ -33,7 +38,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("linked_cases")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         resp = self.linked_cases_api.delete(
             case_id = self.case_id,
@@ -42,7 +47,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
-    @premium_test
+    @premium_feature
     def test_batch_delete(self):
         ids = [
             self.case_to_link_id_1,

--- a/tests/test_api/test_case/test_linked_cases.py
+++ b/tests/test_api/test_case/test_linked_cases.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import LinkedCasesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import LinkedCasesAPI
 
 
 class test_LinkedCasesAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_linked_cases.py
+++ b/tests/test_api/test_case/test_linked_cases.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import LinkedCasesAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_LinkedCasesAPI(unittest.TestCase):
@@ -12,6 +13,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
         self.case_to_link_id_2 = int(getenv("CASE_TO_LINK_ID_2"))
         self.linked_cases_api = LinkedCasesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.linked_cases_api.create(
             case_id = self.case_id,
@@ -20,6 +22,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_test
     def test_list(self):
         resp = self.linked_cases_api.list(
             case_id = self.case_id
@@ -30,6 +33,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("linked_cases")), list)
 
+    @premium_test
     def test_delete(self):
         resp = self.linked_cases_api.delete(
             case_id = self.case_id,
@@ -38,6 +42,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_test
     def test_batch_delete(self):
         ids = [
             self.case_to_link_id_1,

--- a/tests/test_api/test_case/test_metadata.py
+++ b/tests/test_api/test_case/test_metadata.py
@@ -3,6 +3,7 @@ from os     import getenv
 from time   import time_ns
 from dotenv import load_dotenv
 from tapi   import CaseMetadataAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseMetadataAPI(unittest.TestCase):
@@ -11,6 +12,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.case_id           = int(getenv("CASE_ID"))
         self.case_metadata_api = CaseMetadataAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         rng = time_ns() // 1000
         resp = self.case_metadata_api.create(
@@ -20,6 +22,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_test
     def test_get(self):
         resp = self.case_metadata_api.get(
             case_id = self.case_id,
@@ -31,6 +34,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertIsNotNone(body.get("metadata").get("test"))
 
+    @premium_test
     def test_update(self):
         resp = self.case_metadata_api.update(
             case_id  = self.case_id,
@@ -42,6 +46,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("metadata").get("name"), "New Value Unit Test")
 
+    @premium_test
     def test_list(self):
         resp = self.case_metadata_api.list(
             case_id = self.case_id
@@ -52,6 +57,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("metadata")), dict)
 
+    @premium_test
     def test_delete(self):
         self.case_metadata_api.create(case_id = self.case_id, metadata={"to_delete": "delete me plz"})
 

--- a/tests/test_api/test_case/test_metadata.py
+++ b/tests/test_api/test_case/test_metadata.py
@@ -2,17 +2,22 @@ import unittest
 from os                            import getenv
 from time                          import time_ns
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseMetadataAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseMetadataAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_metadata_api = CaseMetadataAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         rng = time_ns() // 1000
         resp = self.case_metadata_api.create(
@@ -22,7 +27,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_metadata_api.get(
             case_id = self.case_id,
@@ -34,7 +39,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertIsNotNone(body.get("metadata").get("test"))
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         resp = self.case_metadata_api.update(
             case_id  = self.case_id,
@@ -46,7 +51,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("metadata").get("name"), "New Value Unit Test")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_metadata_api.list(
             case_id = self.case_id
@@ -57,7 +62,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("metadata")), dict)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         self.case_metadata_api.create(case_id = self.case_id, metadata={"to_delete": "delete me plz"})
 

--- a/tests/test_api/test_case/test_metadata.py
+++ b/tests/test_api/test_case/test_metadata.py
@@ -1,9 +1,9 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from dotenv import load_dotenv
-from tapi   import CaseMetadataAPI
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseMetadataAPI
 
 
 class test_CaseMetadataAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_notes.py
+++ b/tests/test_api/test_case/test_notes.py
@@ -3,19 +3,24 @@ from os                            import getenv
 from time                          import time_ns
 from dotenv                        import load_dotenv
 from tapi                          import CaseNotesAPI
-from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types              import CaseNoteColor
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseMetadataAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.note_to_get_id    = int(getenv("CASE_NOTE_TO_GET"))
         self.note_to_update_id = int(getenv("CASE_NOTE_TO_UPDATE"))
         self.case_notes_api    = CaseNotesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     @unittest.skip("Hitting cap limit")
     def test_create(self):
         resp = self.case_notes_api.create(
@@ -32,7 +37,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("content"), "This is a comment created with Tapi :)")
         self.assertEqual(body.get("color"), CaseNoteColor.BLUE)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_notes_api.get(
             case_id = self.case_id,
@@ -44,7 +49,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("title"), "Note to Get")
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         update_time = time_ns() // 1000
 
@@ -63,7 +68,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("color"), CaseNoteColor.MAGENTA)
         self.assertEqual(body.get("content"), f"This content has been updated at: {update_time}")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_notes_api.list(
             case_id = self.case_id
@@ -74,7 +79,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("notes")), list)
 
-    @premium_test
+    @premium_feature
     @unittest.skip("Function runs fine but apparently there is a limit on how much metadata a case can have")
     def test_delete(self):
         note = self.case_notes_api.create(

--- a/tests/test_api/test_case/test_notes.py
+++ b/tests/test_api/test_case/test_notes.py
@@ -3,6 +3,7 @@ from os               import getenv
 from time             import time_ns
 from dotenv           import load_dotenv
 from tapi             import CaseNotesAPI
+from tapi.utils.testing_decorators import premium_test
 from tapi.utils.types import CaseNoteColor
 
 
@@ -14,6 +15,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.note_to_update_id = int(getenv("CASE_NOTE_TO_UPDATE"))
         self.case_notes_api    = CaseNotesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     @unittest.skip("Hitting cap limit")
     def test_create(self):
         resp = self.case_notes_api.create(
@@ -30,6 +32,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("content"), "This is a comment created with Tapi :)")
         self.assertEqual(body.get("color"), CaseNoteColor.BLUE)
 
+    @premium_test
     def test_get(self):
         resp = self.case_notes_api.get(
             case_id = self.case_id,
@@ -41,6 +44,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("title"), "Note to Get")
 
+    @premium_test
     def test_update(self):
         update_time = time_ns() // 1000
 
@@ -59,6 +63,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("color"), CaseNoteColor.MAGENTA)
         self.assertEqual(body.get("content"), f"This content has been updated at: {update_time}")
 
+    @premium_test
     def test_list(self):
         resp = self.case_notes_api.list(
             case_id = self.case_id
@@ -69,6 +74,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("notes")), list)
 
+    @premium_test
     @unittest.skip("Function runs fine but apparently there is a limit on how much metadata a case can have")
     def test_delete(self):
         note = self.case_notes_api.create(

--- a/tests/test_api/test_case/test_notes.py
+++ b/tests/test_api/test_case/test_notes.py
@@ -1,10 +1,10 @@
 import unittest
-from os               import getenv
-from time             import time_ns
-from dotenv           import load_dotenv
-from tapi             import CaseNotesAPI
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
+from tapi                          import CaseNotesAPI
 from tapi.utils.testing_decorators import premium_test
-from tapi.utils.types import CaseNoteColor
+from tapi.utils.types              import CaseNoteColor
 
 
 class test_CaseMetadataAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_records.py
+++ b/tests/test_api/test_case/test_records.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import CaseRecordsAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseFilesAPI(unittest.TestCase):
@@ -12,6 +13,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.delete_record_id = int(getenv("CASE_DELETE_RECORD_ID"))
         self.case_records_api = CaseRecordsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.case_records_api.create(
             case_id   = self.case_id,
@@ -20,6 +22,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_test
     def test_get(self):
         resp = self.case_records_api.get(
             case_id   = self.case_id,
@@ -32,6 +35,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("record").get("id"), self.record_id)
         self.assertEqual(body.get("record").get("record_type"), {"id": 1419, "name": "Record Unit Test"})
 
+    @premium_test
     def test_list(self):
         resp = self.case_records_api.list(
             case_id = self.case_id
@@ -42,6 +46,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("records")), list)
 
+    @premium_test
     def test_delete(self):
         record = self.case_records_api.create(
             case_id   = self.case_id,

--- a/tests/test_api/test_case/test_records.py
+++ b/tests/test_api/test_case/test_records.py
@@ -1,19 +1,24 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
 from tapi                          import CaseRecordsAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id          = int(getenv("CASE_ID"))
         self.record_id        = int(getenv("CASE_RECORD_ID"))
         self.delete_record_id = int(getenv("CASE_DELETE_RECORD_ID"))
         self.case_records_api = CaseRecordsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_records_api.create(
             case_id   = self.case_id,
@@ -22,7 +27,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         resp = self.case_records_api.get(
             case_id   = self.case_id,
@@ -35,7 +40,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("record").get("id"), self.record_id)
         self.assertEqual(body.get("record").get("record_type"), {"id": 1419, "name": "Record Unit Test"})
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_records_api.list(
             case_id = self.case_id
@@ -46,7 +51,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("records")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         record = self.case_records_api.create(
             case_id   = self.case_id,

--- a/tests/test_api/test_case/test_records.py
+++ b/tests/test_api/test_case/test_records.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseRecordsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseRecordsAPI
 
 
 class test_CaseFilesAPI(unittest.TestCase):

--- a/tests/test_api/test_case/test_subscribers.py
+++ b/tests/test_api/test_case/test_subscribers.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import CaseSubscribersAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_CaseFilesAPI(unittest.TestCase):
@@ -11,6 +12,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.case_sub_email       = getenv("CASE_SUBSCRIBER_EMAIL")
         self.case_subscribers_api = CaseSubscribersAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_test
     def test_create(self):
         resp = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -19,6 +21,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_test
     def test_list(self):
         resp = self.case_subscribers_api.list(
             case_id = self.case_id
@@ -29,6 +32,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("subscribers")), list)
 
+    @premium_test
     def test_delete(self):
         subscriber = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -44,6 +48,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_test
     def test_batch_create(self):
         resp = self.case_subscribers_api.batch_create(
             case_id = self.case_id,

--- a/tests/test_api/test_case/test_subscribers.py
+++ b/tests/test_api/test_case/test_subscribers.py
@@ -1,18 +1,23 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import CaseSubscribersAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id              = int(getenv("CASE_ID"))
         self.case_sub_email       = getenv("CASE_SUBSCRIBER_EMAIL")
         self.case_subscribers_api = CaseSubscribersAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -21,7 +26,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         resp = self.case_subscribers_api.list(
             case_id = self.case_id
@@ -32,7 +37,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("subscribers")), list)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         subscriber = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -48,7 +53,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
-    @premium_test
+    @premium_feature
     def test_batch_create(self):
         resp = self.case_subscribers_api.batch_create(
             case_id = self.case_id,

--- a/tests/test_api/test_case/test_subscribers.py
+++ b/tests/test_api/test_case/test_subscribers.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseSubscribersAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import CaseSubscribersAPI
 
 
 class test_CaseFilesAPI(unittest.TestCase):

--- a/tests/test_api/test_credential/test_credentials.py
+++ b/tests/test_api/test_credential/test_credentials.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CredentialsAPI
-from time   import time_ns
+from os              import getenv
+from time            import time_ns
+from dotenv          import load_dotenv
+from tapi            import CredentialsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_CredentialsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_cred       = None
         self.cred_id         = int(getenv("CREDENTIAL_ID"))
         self.team_id         = int(getenv("TEAM_ID"))

--- a/tests/test_api/test_event/test_events.py
+++ b/tests/test_api/test_event/test_events.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from tapi   import EventsAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import EventsAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_EventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.event_id        = int(getenv("EVENT_ID"))
         self.event_action_id = int(getenv("EVENT_ACTION_ID"))
         self.events_api      = EventsAPI(getenv("DOMAIN"), getenv("API_KEY"))

--- a/tests/test_api/test_folder/test_folders.py
+++ b/tests/test_api/test_folder/test_folders.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from tapi   import FoldersAPI
-from dotenv import load_dotenv
+from os              import getenv
+from time            import time_ns
+from tapi            import FoldersAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_EventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_folder_id = None
         self.folder_id      = int(getenv("FOLDER_ID"))
         self.team_id        = int(getenv("TEAM_ID"))
@@ -75,7 +81,7 @@ class test_EventsAPI(unittest.TestCase):
 
     def test_delete(self):
         folder = self.folders_api.create(
-            name         = f"To Delete",
+            name         = "To Delete",
             content_type = "STORY",
             team_id      = self.team_id
         )

--- a/tests/test_api/test_note/test_notes.py
+++ b/tests/test_api/test_note/test_notes.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from random import randint
-from tapi   import NotesAPI
-from dotenv import load_dotenv
+from os              import getenv
+from random          import randint
+from tapi            import NotesAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_NotesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.note_id   = int(getenv("NOTE_ID"))
         self.story_id  = int(getenv("NOTE_STORY_ID"))
         self.notes_api = NotesAPI(getenv("DOMAIN"), getenv("API_KEY"))

--- a/tests/test_api/test_resource/test_resources.py
+++ b/tests/test_api/test_resource/test_resources.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from dotenv import load_dotenv
-from tapi   import ResourcesAPI
+from os              import getenv
+from time            import time_ns
+from dotenv          import load_dotenv
+from tapi            import ResourcesAPI
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_ResourcesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_resource_id   = None
         self.team_id            = int(getenv("TEAM_ID"))
         self.resource_id        = int(getenv("RESOURCE_ID"))

--- a/tests/test_api/test_story/test_change_requests.py
+++ b/tests/test_api/test_story/test_change_requests.py
@@ -1,8 +1,8 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ChangeRequestAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
 from tapi.utils.testing_decorators import premium_test
+from tapi                          import ChangeRequestAPI
 
 
 class test_ChangeRequestAPI(unittest.TestCase):

--- a/tests/test_api/test_story/test_change_requests.py
+++ b/tests/test_api/test_story/test_change_requests.py
@@ -1,14 +1,19 @@
 import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
 from tapi                          import ChangeRequestAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_ChangeRequestAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id            = getenv("TEAM_ID")
         self.story_id           = int(getenv("CHANGE_REQUEST_STORY_ID"))
         self.change_request_api = ChangeRequestAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -20,7 +25,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
             change_request_id = self.change_request_id
         )
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.change_request_api.create(
             story_id    = self.story_id,
@@ -34,7 +39,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("id")), int)
         self.assertEqual(type(resp.get("body").get("change_request")), dict)
 
-    @premium_test
+    @premium_feature
     def test_approve(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -56,7 +61,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(resp.get("body").get("change_request").get("status"), "APPROVED")
 
-    @premium_test
+    @premium_feature
     def test_cancel(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -75,7 +80,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(type(resp.get("body").get("id")), int)
 
-    @premium_test
+    @premium_feature
     def test_promote(self):
         create_request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -101,7 +106,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("name"), "Testing")
         self.assertEqual(resp.get("body").get("id"), self.story_id)
 
-    @premium_test
+    @premium_feature
     def test_view(self):
         resp = self.change_request_api.view(
             story_id = self.story_id

--- a/tests/test_api/test_story/test_change_requests.py
+++ b/tests/test_api/test_story/test_change_requests.py
@@ -2,6 +2,7 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import ChangeRequestAPI
+from tapi.utils.testing_decorators import premium_test
 
 
 class test_ChangeRequestAPI(unittest.TestCase):
@@ -19,6 +20,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
             change_request_id = self.change_request_id
         )
 
+    @premium_test
     def test_create(self):
         resp = self.change_request_api.create(
             story_id    = self.story_id,
@@ -32,6 +34,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("id")), int)
         self.assertEqual(type(resp.get("body").get("change_request")), dict)
 
+    @premium_test
     def test_approve(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -53,6 +56,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(resp.get("body").get("change_request").get("status"), "APPROVED")
 
+    @premium_test
     def test_cancel(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -71,6 +75,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(type(resp.get("body").get("id")), int)
 
+    @premium_test
     def test_promote(self):
         create_request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -96,6 +101,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("name"), "Testing")
         self.assertEqual(resp.get("body").get("id"), self.story_id)
 
+    @premium_test
     def test_view(self):
         resp = self.change_request_api.view(
             story_id = self.story_id

--- a/tests/test_api/test_story/test_runs.py
+++ b/tests/test_api/test_story/test_runs.py
@@ -1,15 +1,20 @@
 import unittest
-from os     import getenv
-from tapi   import RunsAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import RunsAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_RunsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.story_id       = int(getenv("RUNS_API_STORY_ID"))
-        self.runs_api       = RunsAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.story_run_guid = getenv("RUNS_API_STORY_RUN_GUID")
+        self.runs_api       = RunsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
     def test_events(self):
         resp = self.runs_api.events(

--- a/tests/test_api/test_story/test_stories.py
+++ b/tests/test_api/test_story/test_stories.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from tapi   import StoriesAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import StoriesAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_StoriesAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.stories_api = StoriesAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.team_id     = int(getenv("TEAM_ID"))
         self.story_id    = None

--- a/tests/test_api/test_story/test_versions.py
+++ b/tests/test_api/test_story/test_versions.py
@@ -1,7 +1,7 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import VersionsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import VersionsAPI
 from tapi.utils.testing_decorators import premium_test
 
 

--- a/tests/test_api/test_story/test_versions.py
+++ b/tests/test_api/test_story/test_versions.py
@@ -2,12 +2,17 @@ import unittest
 from os                            import getenv
 from dotenv                        import load_dotenv
 from tapi                          import VersionsAPI
-from tapi.utils.testing_decorators import premium_test
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_VersionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.version_id   = None
         self.story_id     = int(getenv("VERSIONS_API_STORY_ID"))
         self.versions_api = VersionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -19,7 +24,7 @@ class test_VersionsAPI(unittest.TestCase):
                 version_id = self.version_id
             )
 
-    @premium_test
+    @premium_feature
     def test_create(self):
         resp = self.versions_api.create(
             story_id = self.story_id,
@@ -31,7 +36,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"),                           200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "Create Version Unit Test")
 
-    @premium_test
+    @premium_feature
     def test_get(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -50,7 +55,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("story_version").get("export_file"))
         self.assertEqual(type(resp.get("body").get("story_version").get("export_file")), dict)
 
-    @premium_test
+    @premium_feature
     def test_update(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -68,7 +73,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "New Version Unit Test Name")
 
-    @premium_test
+    @premium_feature
     def test_list(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -85,7 +90,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("story_versions")), list)
         self.assertGreaterEqual(len(resp.get("body").get("story_versions")), 1)
 
-    @premium_test
+    @premium_feature
     def test_delete(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,

--- a/tests/test_api/test_story/test_versions.py
+++ b/tests/test_api/test_story/test_versions.py
@@ -2,6 +2,8 @@ import unittest
 from os     import getenv
 from dotenv import load_dotenv
 from tapi   import VersionsAPI
+from tapi.utils.testing_decorators import premium_test
+
 
 class test_VersionsAPI(unittest.TestCase):
     def setUp(self):
@@ -17,6 +19,7 @@ class test_VersionsAPI(unittest.TestCase):
                 version_id = self.version_id
             )
 
+    @premium_test
     def test_create(self):
         resp = self.versions_api.create(
             story_id = self.story_id,
@@ -28,6 +31,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"),                           200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "Create Version Unit Test")
 
+    @premium_test
     def test_get(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -46,6 +50,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("story_version").get("export_file"))
         self.assertEqual(type(resp.get("body").get("story_version").get("export_file")), dict)
 
+    @premium_test
     def test_update(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -63,6 +68,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "New Version Unit Test Name")
 
+    @premium_test
     def test_list(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -79,6 +85,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("story_versions")), list)
         self.assertGreaterEqual(len(resp.get("body").get("story_versions")), 1)
 
+    @premium_test
     def test_delete(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,

--- a/tests/test_api/test_team/test_members.py
+++ b/tests/test_api/test_team/test_members.py
@@ -3,11 +3,16 @@ from tapi.utils.types import Role
 from os               import getenv
 from tapi             import MembersAPI
 from dotenv           import load_dotenv
+from tapi.utils.http  import disable_ssl_verification
 
 
 class test_MembersAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id     = int(getenv("TEAM_ID"))
         self.members_api = MembersAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_team/test_teams.py
+++ b/tests/test_api/test_team/test_teams.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from tapi   import TeamsAPI
-from dotenv import load_dotenv
+from os                            import getenv
+from tapi                          import TeamsAPI
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_TeamsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.teams_api = TeamsAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.team_id   = None
 
@@ -16,6 +22,7 @@ class test_TeamsAPI(unittest.TestCase):
                 team_id = self.team_id
             )
 
+    @premium_feature
     def test_create(self):
         resp = self.teams_api.create(
             name = "Create Team Unit Test"
@@ -26,6 +33,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(resp.get("body").get("name"), "Create Team Unit Test")
 
+    @premium_feature
     def test_get(self):
         team = self.teams_api.create(
             name = "Get Team Unit Test"
@@ -42,6 +50,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("name"), "Get Team Unit Test")
         self.assertEqual(type(resp.get("body").get("groups")), list)
 
+    @premium_feature
     def test_update(self):
         team = self.teams_api.create(
             name = "Update Team Unit Test"
@@ -58,6 +67,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("id"), self.team_id)
         self.assertEqual(resp.get("body").get("name"), "New Updated Team Unit Test")
 
+    @premium_feature
     def test_list(self):
         team = self.teams_api.create(
             name = "List Team Unit Test"
@@ -71,6 +81,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("teams")), list)
         self.assertGreaterEqual(len(resp.get("body").get("teams")), 1)
 
+    @premium_feature
     def test_delete(self):
         team = self.teams_api.create(
             name="Delete Team Unit Test"

--- a/tests/test_api/test_tenant.py
+++ b/tests/test_api/test_tenant.py
@@ -2,12 +2,17 @@ import unittest
 from os     import getenv
 from tapi   import TenantAPI
 from dotenv import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_TenantAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.tenant_api = TenantAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
     def test_info(self):

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -1,12 +1,17 @@
 import unittest
-from os          import getenv
-from tapi.client import Client
-from dotenv      import load_dotenv
+from os              import getenv
+from tapi.client     import Client
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_Client(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.DOMAIN  = getenv("DOMAIN")
         self.API_KEY = getenv("API_KEY")
 
@@ -16,21 +21,21 @@ class test_Client(unittest.TestCase):
 
     def test_http_request_with_good_credentials(self):
         client = Client(self.DOMAIN, self.API_KEY)
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 200)
 
     def test_http_request_with_bad_api_key(self):
         client = Client(self.DOMAIN, "API_KEY")
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 401)
 
     def test_http_request_with_bad_domain(self):
         client = Client("DOMAIN", self.API_KEY)
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 500)


### PR DESCRIPTION
Separated community tests from paid features. 

Run all the tests (community + paid features):
```bash
SKIP_PREMIUM_TESTS=0 py -m unittest
```

Run community tests:
```bash
SKIP_PREMIUM_TESTS=1 py -m unittest
```

Disabling SSL during testing:
```bash
SSL_VERIFICATION=0 py -m unittest
```

This env vars can also be used together

Disabling SSL and run only community tests:
```bash
SSL_VERIFICATION=0 SKIP_PREMIUM_TESTS=1 py -m unittest
```

