### PR TITLE
Adding support for Records endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,23 +96,14 @@ def main():
     
     tenant = TenantAPI(DOMAIN, API_KEY)
     
-    cases = tenant.cases.list()
+    tenant_info = tenant.info()
     
-    print(dumps(cases, indent = 4))
+    print(dumps(tenant_info, indent = 4))
 ```
 ```json5
 {
     "body": {
-        "cases": [
-            {
-                "case_id": 1,
-                "name": "My Case Name",
-                "description": "",
-                "status": "OPEN",
-                //...[snip]...//
-            }
-        //...[snip]...//
-        ]
+        "stack": {...}
     },
     "headers": {...},
     "status_code": ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tapi (Tines API)
+# About Tapi
 A simple Python wrapper for the Tines API.
 
 ## ⚠ Disclaimer 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This class provides access to all endpoints offered by the Tines API.
 from tapi import TenantAPI
 
 def main():
-    tenant = TenantAPI(<DOMAIN>, <API_KEY>)
+    tenant = TenantAPI("<DOMAIN>", "<API_KEY>")
     teams = tenant.teams.list()
     cases = tenant.cases.list()
     stories = tenant.stories.list()
@@ -79,6 +79,7 @@ This class is designed to be used as a "parent" class from which all other endpo
 | `TenantAPI.events`      | `EventsAPI`      | Manage tenant-wide action events. |
 | `TenantAPI.stories`     | `StoriesAPI`     | Manage workflows.                 |
 | `TenantAPI.folders`     | `FoldersAPI`     | Manage folders.                   |
+| `TenantAPI.records`     | `RecordsAPI`     | Manage records.                   |
 | `TenantAPI.resources`   | `ResourcesAPI`   | Manage resources.                 |
 | `TenantAPI.audit_logs`  | `AuditLogsAPI`   | Pull tenant logs.                 |
 | `TenantAPI.credentials` | `CredentialsAPI` | Manage tenant credentials.        |
@@ -1729,3 +1730,150 @@ def main():
 
 </details>
 
+<details>
+<summary>RecordsAPI</summary>
+Manage actions.
+
+### Methods
+
+| **Method**     | **Description**             |
+|----------------|-----------------------------|
+| `create`       | Create record.              |
+| `get`          | Retrieve a single record.   |
+| `update`       | Updates a single record.    |
+| `list`         | Retrieve a list of records. |
+| `delete`       | Delete a record.            |
+
+
+### Subclasses
+
+| **Path**                      | **Class**            | **Description**           |
+|-------------------------------|----------------------|---------------------------|
+| `TenantAPI.records.types`     | `RecordTypesAPI`     | Manage record types.      |
+| `TenantAPI.records.artifacts` | `RecordArtifactsAPI` | Manage records artifacts. |
+
+
+### Usage:
+
+```python
+from json import dumps
+from tapi import RecordsAPI
+
+def main():
+    DOMAIN  = "my-cool-domain-1234"
+    API_KEY = "do_not_put_this_on_github_lol"
+    
+    records_api = RecordsAPI(DOMAIN, API_KEY)
+    
+    records = records_api.list(record_type_id=1234)
+    
+    print(dumps(records, indent = 4))
+```
+```json5
+{
+    "body": {
+        "record_results": [...],
+        //...[snip]...//
+    },
+    "headers": {...},
+    "status_code": ...
+}
+```
+
+</details>
+
+<details>
+<summary>RecordTypesAPI</summary>
+Manage resources
+
+### Methods
+
+| **Method**        | **Description**                  |
+|-------------------|----------------------------------|
+| `create`          | Create a new record type.        |
+| `get`             | Retrieve a single record type.   |
+| `list`            | Retrieve a list of record types. |
+| `delete`          | Delete a record type.            |
+
+### Subclasses
+- **None**
+
+### Usage:
+
+```python
+from json import dumps
+from tapi import RecordTypesAPI
+
+
+def main():
+    DOMAIN = "my-cool-domain-1234"
+    API_KEY = "do_not_put_this_on_github_lol"
+
+    record_types_api = RecordTypesAPI(DOMAIN, API_KEY)
+
+    record_types = record_types_api.list(team_id=1234)
+
+    print(dumps(record_types, indent=4))
+```
+```json5
+{
+    "body": {
+        "record_types":[...],
+        //...[snip]...//
+    },
+    "headers": {...},
+    "status_code": ...
+}
+```
+
+</details>
+
+<details>
+<summary>RecordArtifactsAPI</summary>
+Manage resources
+
+### Methods
+
+| **Method**        | **Description**                         |
+|-------------------|-----------------------------------------|
+| `get`             | Retrieve an individual record artifact. |
+
+### Subclasses
+- **None**
+
+### Usage:
+
+```python
+from json import dumps
+from tapi import RecordArtifactsAPI
+
+
+def main():
+    DOMAIN = "my-cool-domain-1234"
+    API_KEY = "do_not_put_this_on_github_lol"
+
+    record_artifacts_api = RecordArtifactsAPI(DOMAIN, API_KEY)
+
+    record_artifacts = record_artifacts_api.get(record_id = 1234, artifact_id = 5678)
+
+    print(dumps(record_artifacts, indent=4))
+```
+```json5
+{
+    "body": {
+        "id": 1,
+        "value": "artifact value",
+        "record_field": {
+            "id": 1,
+            "name": "record field name"
+        },
+        "created_at": "2024-02-16T15:37:39Z",
+        "updated_at": "2024-02-16T15:37:39Z"
+        //...[snip]...//
+    },
+    "headers": {...},
+    "status_code": ...
+}
+```
+
+</details>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name                          = "tapi",
-    version                       = "0.0.10",
+    version                       = "0.0.11",
     description                   = "Tines REST API wrapper",
     long_description              = long_description,
     long_description_content_type = "text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name                          = "tapi",
-    version                       = "0.0.9",
+    version                       = "0.0.10",
     description                   = "Tines REST API wrapper",
     long_description              = long_description,
     long_description_content_type = "text/markdown",

--- a/tapi/api/__init__.py
+++ b/tapi/api/__init__.py
@@ -5,6 +5,7 @@ from .story      import *
 from .event      import *
 from .folder     import *
 from .action     import *
+from .record     import *
 from .resource   import *
 from .audit_log  import *
 from .credential import *
@@ -31,7 +32,8 @@ __all__ = [
 
     "ResourcesAPI",
 
+    "RecordsAPI", "RecordTypesAPI", "RecordArtifactsAPI",
+
     "StoriesAPI", "ChangeRequestAPI", "RunsAPI", "VersionsAPI",
     "TeamsAPI", "MembersAPI"
 ]
-

--- a/tapi/api/action/actions.py
+++ b/tapi/api/action/actions.py
@@ -6,7 +6,7 @@ from typing           import List, Dict, Any, Optional, Union
 
 
 class ActionsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "actions"
         self.logs   = ActionLogsAPI(domain, apiKey)

--- a/tapi/api/action/events.py
+++ b/tapi/api/action/events.py
@@ -3,7 +3,7 @@ from typing      import Optional
 
 
 class ActionEventsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "actions"
 

--- a/tapi/api/action/logs.py
+++ b/tapi/api/action/logs.py
@@ -4,7 +4,7 @@ from tapi.utils.types import LogSeverityLevel
 
 
 class ActionLogsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "actions"
 

--- a/tapi/api/audit_log/audit_logs.py
+++ b/tapi/api/audit_log/audit_logs.py
@@ -4,7 +4,7 @@ from typing           import Optional, List, Union
 
 
 class AuditLogsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "audit_logs"
 

--- a/tapi/api/case/actions.py
+++ b/tapi/api/case/actions.py
@@ -4,7 +4,7 @@ from typing           import List, Optional, Dict, Any, Union
 
 
 class CaseActionsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/activities.py
+++ b/tapi/api/case/activities.py
@@ -4,7 +4,7 @@ from tapi.utils.types import CaseActivityType
 
 
 class CaseActivitiesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/assignees.py
+++ b/tapi/api/case/assignees.py
@@ -2,7 +2,7 @@ from tapi.client import Client
 
 
 class CaseAssigneesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/cases.py
+++ b/tapi/api/case/cases.py
@@ -16,7 +16,7 @@ from tapi.utils.types import CasePriority, CaseStatus, CaseReturnOrder
 
 
 class CaseAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
         self.files         = CaseFilesAPI(domain, apiKey)

--- a/tapi/api/case/comments.py
+++ b/tapi/api/case/comments.py
@@ -4,7 +4,7 @@ from typing           import Optional, Union
 
 
 class CaseCommentsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
         self.reactions     = CaseCommentsReactionsAPI(domain, apiKey)
@@ -71,7 +71,7 @@ class CaseCommentsAPI(Client):
         )
 
 class CaseCommentsReactionsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/fields.py
+++ b/tapi/api/case/fields.py
@@ -3,7 +3,7 @@ from tapi.client import Client
 
 
 class CaseFieldsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/files.py
+++ b/tapi/api/case/files.py
@@ -3,7 +3,7 @@ from typing      import Optional
 
 
 class CaseFilesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/inputs.py
+++ b/tapi/api/case/inputs.py
@@ -4,7 +4,7 @@ from tapi.utils.types import CaseInputType, CaseValidationType
 
 
 class CaseInputsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "case_inputs"
         self.fields        = CaseInputsFieldsAPI(domain, apiKey)
@@ -47,7 +47,7 @@ class CaseInputsAPI(Client):
         )
 
 class CaseInputsFieldsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "case_inputs"
 

--- a/tapi/api/case/linked_cases.py
+++ b/tapi/api/case/linked_cases.py
@@ -3,7 +3,7 @@ from tapi.client import Client
 
 
 class LinkedCasesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/metadata.py
+++ b/tapi/api/case/metadata.py
@@ -3,7 +3,7 @@ from typing      import List, Dict
 
 
 class CaseMetadataAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/notes.py
+++ b/tapi/api/case/notes.py
@@ -4,7 +4,7 @@ from typing           import Optional, Union
 
 
 class CaseNotesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/records.py
+++ b/tapi/api/case/records.py
@@ -2,7 +2,7 @@ from tapi.client import Client
 
 
 class CaseRecordsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/case/subscribers.py
+++ b/tapi/api/case/subscribers.py
@@ -3,7 +3,7 @@ from tapi.client import Client
 
 
 class CaseSubscribersAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "cases"
 

--- a/tapi/api/credential/credentials.py
+++ b/tapi/api/credential/credentials.py
@@ -3,7 +3,7 @@ from typing      import Literal, Optional, List, Dict, Any
 
 
 class CredentialsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "user_credentials"
 

--- a/tapi/api/event/events.py
+++ b/tapi/api/event/events.py
@@ -3,7 +3,7 @@ from typing      import Optional
 
 
 class EventsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "events"
 

--- a/tapi/api/folder/folders.py
+++ b/tapi/api/folder/folders.py
@@ -3,7 +3,7 @@ from typing      import Optional, Literal
 
 
 class FoldersAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "folders"
 

--- a/tapi/api/note/notes.py
+++ b/tapi/api/note/notes.py
@@ -4,7 +4,7 @@ from typing           import Optional, Dict, Union
 
 
 class NotesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "notes"
 

--- a/tapi/api/record/__init__.py
+++ b/tapi/api/record/__init__.py
@@ -1,0 +1,7 @@
+from .records   import RecordsAPI
+from .types     import RecordTypesAPI
+from .artifacts import RecordArtifactsAPI
+
+__all__ = [
+    "RecordsAPI", "RecordTypesAPI", "RecordArtifactsAPI"
+]

--- a/tapi/api/record/artifacts.py
+++ b/tapi/api/record/artifacts.py
@@ -1,0 +1,17 @@
+from tapi.client import Client
+
+
+class RecordArtifactsAPI(Client):
+    def __init__(self, domain, apiKey):
+        super().__init__(domain, apiKey)
+        self.base_endpoint = "records"
+
+    def get(
+            self,
+            record_id:   int,
+            artifact_id: int
+    ):
+        return self._http_request(
+            "GET",
+            f"{self.base_endpoint}/{record_id}/artifacts/{artifact_id}"
+        )

--- a/tapi/api/record/artifacts.py
+++ b/tapi/api/record/artifacts.py
@@ -2,7 +2,7 @@ from tapi.client import Client
 
 
 class RecordArtifactsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "records"
 

--- a/tapi/api/record/records.py
+++ b/tapi/api/record/records.py
@@ -6,7 +6,7 @@ from typing           import Optional, Dict, List, Union, Any, Literal
 
 
 class RecordsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "records"
         self.types         = RecordTypesAPI(domain, apiKey)

--- a/tapi/api/record/records.py
+++ b/tapi/api/record/records.py
@@ -1,0 +1,85 @@
+from tapi.client      import Client
+from .types           import RecordTypesAPI
+from .artifacts       import RecordArtifactsAPI
+from tapi.utils.types import RecordFieldValue, RecordFilter
+from typing           import Optional, Dict, List, Union, Any, Literal
+
+
+class RecordsAPI(Client):
+    def __init__(self, domain, apiKey):
+        super().__init__(domain, apiKey)
+        self.base_endpoint = "records"
+        self.types         = RecordTypesAPI(domain, apiKey)
+        self.artifacts     = RecordArtifactsAPI(domain, apiKey)
+
+    def create(
+            self,
+            record_type_id: int,
+            field_values:   List[Union[RecordFieldValue, Dict[str, Any]]],
+            case_ids:       Optional[List[Union[str, int]]]        = None,
+            test_mode:      bool                                   = False
+    ):
+        return self._http_request(
+            "POST",
+            self.base_endpoint,
+            json = {key: value for key, value in locals().items() if value is not None and key != "self"}
+        )
+
+    def get(
+            self,
+            record_id: int
+    ):
+        return self._http_request(
+            "GET",
+            f"{self.base_endpoint}/{record_id}"
+        )
+
+    def list(
+            self,
+            record_type_id:   Optional[int]                                       = None,
+            record_field_ids: Optional[int]                                       = None,
+            range_start:      Optional[Union[str, int]]                           = None,
+            range_end:        Optional[Union[str, int]]                           = None,
+            story_ids:        Optional[List[Union[str, int]]]                     = None,
+            order_direction:  Literal["ASC", "DESC"]                              = "DESC",
+            order_field_id:   Optional[int]                                       = None,
+            filters:          Optional[List[RecordFilter, Union[Dict[str, str]]]] = None,
+            test_mode:        Optional[bool]                                      = None,
+            per_page:         int                                                 = 10,
+            page:             int                                                 = 1
+    ):
+        if not record_type_id and not record_field_ids:
+            raise ValueError("Please specify either 'record_type_id' or 'record_field_ids'.")
+        elif record_type_id and record_field_ids:
+            raise ValueError("Please specify only one of 'record_type_id' or 'record_field_ids', not both.")
+
+        return self._http_request(
+            "GET",
+            self.base_endpoint,
+            params = {key: value for key, value in locals().items() if value is not None and key != "self"}
+        )
+
+    def update(
+            self,
+            record_id: int,
+            add_child_records:    Optional[List[Union[str, int]]]               = None,
+            remove_child_records: Optional[List[Union[str, int]]]               = None,
+            add_team_case_ids:    Optional[List[Union[str, int]]]               = None,
+            remove_team_case_ids: Optional[List[Union[str, int]]]               = None,
+            field_values:         List[Union[RecordFieldValue, Dict[str, Any]]] = None
+    ):
+        return self._http_request(
+            "PUT",
+            f"{self.base_endpoint}/{record_id}",
+            json = {key: value for key, value in locals().items()
+                    if value is not None and key not in ("self", "record_id")}
+        )
+
+    def delete(
+            self,
+            record_id: int
+    ):
+        return self._http_request(
+            "DELETE",
+            f"{self.base_endpoint}/{record_id}"
+        )

--- a/tapi/api/record/records.py
+++ b/tapi/api/record/records.py
@@ -36,17 +36,17 @@ class RecordsAPI(Client):
 
     def list(
             self,
-            record_type_id:   Optional[int]                                       = None,
-            record_field_ids: Optional[int]                                       = None,
-            range_start:      Optional[Union[str, int]]                           = None,
-            range_end:        Optional[Union[str, int]]                           = None,
-            story_ids:        Optional[List[Union[str, int]]]                     = None,
-            order_direction:  Literal["ASC", "DESC"]                              = "DESC",
-            order_field_id:   Optional[int]                                       = None,
-            filters:          Optional[List[RecordFilter, Union[Dict[str, str]]]] = None,
-            test_mode:        Optional[bool]                                      = None,
-            per_page:         int                                                 = 10,
-            page:             int                                                 = 1
+            record_type_id:   Optional[int]                                              = None,
+            record_field_ids: Optional[int]                                              = None,
+            range_start:      Optional[Union[str, int]]                                  = None,
+            range_end:        Optional[Union[str, int]]                                  = None,
+            story_ids:        Optional[List[Union[str, int]]]                            = None,
+            order_direction:  Literal["ASC", "DESC"]                                     = "DESC",
+            order_field_id:   Optional[int]                                              = None,
+            filters:          Optional[List[Union[RecordFilter, Union[Dict[str, str]]]]] = None,
+            test_mode:        Optional[bool]                                             = None,
+            per_page:         int                                                        = 10,
+            page:             int                                                        = 1
     ):
         if not record_type_id and not record_field_ids:
             raise ValueError("Please specify either 'record_type_id' or 'record_field_ids'.")

--- a/tapi/api/record/types.py
+++ b/tapi/api/record/types.py
@@ -11,9 +11,9 @@ class RecordTypesAPI(Client):
             self,
             name:     str,
             team_id:  int,
-            fields:   Optional[List[Dict[str, Union[str, int, bool]]]] = None,
-            editable: Optional[bool]                                   = None,
-            ttl_days: Optional[int]                                    = None
+            fields:   List[Dict[str, Union[str, int, bool]]],
+            editable: Optional[bool]                  = None,
+            ttl_days: Optional[int]                   = None
     ):
         return self._http_request(
             "POST",

--- a/tapi/api/record/types.py
+++ b/tapi/api/record/types.py
@@ -1,0 +1,52 @@
+from tapi.client import Client
+from typing      import Dict, Optional, List, Union
+
+
+class RecordTypesAPI(Client):
+    def __init__(self, domain, apiKey):
+        super().__init__(domain, apiKey)
+        self.base_endpoint = "record_types"
+
+    def create(
+            self,
+            name:     str,
+            team_id:  int,
+            fields:   Optional[List[Dict[str, Union[str, int, bool]]]] = None,
+            editable: Optional[bool]                                   = None,
+            ttl_days: Optional[int]                                    = None
+    ):
+        return self._http_request(
+            "POST",
+            self.base_endpoint,
+            json = {key: value for key, value in locals().items() if value is not None and key != "self"}
+        )
+
+    def get(
+            self,
+            record_type_id: int
+    ):
+        return self._http_request(
+            "GET",
+            f"{self.base_endpoint}/{record_type_id}"
+        )
+
+    def list(
+            self,
+            team_id:  int,
+            per_page: int = 10,
+            page:     int = 1
+    ):
+        return self._http_request(
+            "GET",
+            self.base_endpoint,
+            params = {key: value for key, value in locals().items() if value is not None and key != "self"}
+        )
+
+    def delete(
+            self,
+            record_type_id: int
+    ):
+        return self._http_request(
+            "DELETE",
+            f"{self.base_endpoint}/{record_type_id}"
+        )

--- a/tapi/api/record/types.py
+++ b/tapi/api/record/types.py
@@ -3,7 +3,7 @@ from typing      import Dict, Optional, List, Union
 
 
 class RecordTypesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "record_types"
 

--- a/tapi/api/resource/resources.py
+++ b/tapi/api/resource/resources.py
@@ -3,7 +3,7 @@ from typing      import Optional, Dict, List, Union, Any, Literal
 
 
 class ResourcesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "global_resources"
 

--- a/tapi/api/resource/resources.py
+++ b/tapi/api/resource/resources.py
@@ -3,7 +3,6 @@ from typing      import Optional, Dict, List, Union, Any, Literal
 
 
 class ResourcesAPI(Client):
-
     def __init__(self, domain, apiKey):
         super().__init__(domain, apiKey)
         self.base_endpoint = "global_resources"
@@ -11,8 +10,8 @@ class ResourcesAPI(Client):
     def create(
             self,
             name:              str,
-            value:             Union[str, Dict[str, Any], List[Dict[str, Any]]],
-            team_id:           Optional[int]                               = None,
+            value:             Union[str, Dict[str, Any], List[Union[int, str, Dict[str, Any]]]],
+            team_id:           int                                         = None,
             folder_id:         Optional[int]                               = None,
             read_access:       Literal["TEAM", "GLOBAL", "SPECIFIC_TEAMS"] = "TEAM",
             shared_team_slugs: Optional[List[str]]                         = None,
@@ -20,7 +19,7 @@ class ResourcesAPI(Client):
             live_resource_id:  Optional[int]                               = None,
 
     ):
-        self._http_request(
+        return self._http_request(
             "POST",
             self.base_endpoint,
             json = {key: value for key, value in locals().items() if value is not None and key != "self"}
@@ -30,7 +29,7 @@ class ResourcesAPI(Client):
             self,
             resource_id: int
     ):
-        self._http_request(
+        return self._http_request(
             "GET",
             f"{self.base_endpoint}/{resource_id}"
         )

--- a/tapi/api/story/change_requests.py
+++ b/tapi/api/story/change_requests.py
@@ -3,7 +3,7 @@ from typing      import Optional
 
 
 class ChangeRequestAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "stories"
 

--- a/tapi/api/story/runs.py
+++ b/tapi/api/story/runs.py
@@ -4,7 +4,7 @@ from typing           import Optional, Union
 
 
 class RunsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "stories"
 

--- a/tapi/api/story/stories.py
+++ b/tapi/api/story/stories.py
@@ -123,7 +123,7 @@ class StoriesAPI(Client):
             new_name:  str,
             data:      Dict[str, Any],
             team_id:   int,
-            folder_id: Optional[str]    = None,
+            folder_id: Optional[int]    = None,
             mode:      Union[Mode, str] = Mode.NEW
         ):
         return self._http_request(

--- a/tapi/api/story/stories.py
+++ b/tapi/api/story/stories.py
@@ -9,7 +9,7 @@ from typing           import List, Optional, Dict, Any
 
 
 class StoriesAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint  = "stories"
         self.runs           = RunsAPI(domain, apiKey)

--- a/tapi/api/story/versions.py
+++ b/tapi/api/story/versions.py
@@ -3,7 +3,7 @@ from typing      import Optional
 
 
 class VersionsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "stories"
 

--- a/tapi/api/team/members.py
+++ b/tapi/api/team/members.py
@@ -4,7 +4,7 @@ from typing           import Optional, Union
 
 
 class MembersAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "teams"
 

--- a/tapi/api/team/teams.py
+++ b/tapi/api/team/teams.py
@@ -3,7 +3,7 @@ from .members    import MembersAPI
 
 
 class TeamsAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.base_endpoint = "teams"
         self.members       = MembersAPI(domain, apiKey)

--- a/tapi/api/tenant.py
+++ b/tapi/api/tenant.py
@@ -23,5 +23,5 @@ class TenantAPI(Client):
         self.audit_logs  = AuditLogsAPI(domain, apiKey)
         self.credentials = CredentialsAPI(domain, apiKey)
 
-    def info(self) -> dict:
+    def info(self):
         return self._http_request("GET", "info")

--- a/tapi/api/tenant.py
+++ b/tapi/api/tenant.py
@@ -4,6 +4,7 @@ from .team       import TeamsAPI
 from .event      import EventsAPI
 from .story      import StoriesAPI
 from .folder     import FoldersAPI
+from .record     import RecordsAPI
 from .resource   import ResourcesAPI
 from .audit_log  import AuditLogsAPI
 from .credential import CredentialsAPI
@@ -17,6 +18,7 @@ class TenantAPI(Client):
         self.events      = EventsAPI(domain, apiKey)
         self.stories     = StoriesAPI(domain, apiKey)
         self.folders     = FoldersAPI(domain, apiKey)
+        self.records     = RecordsAPI(domain, apiKey)
         self.resources   = ResourcesAPI(domain, apiKey)
         self.audit_logs  = AuditLogsAPI(domain, apiKey)
         self.credentials = CredentialsAPI(domain, apiKey)

--- a/tapi/api/tenant.py
+++ b/tapi/api/tenant.py
@@ -11,7 +11,7 @@ from .credential import CredentialsAPI
 
 
 class TenantAPI(Client):
-    def __init__(self, domain, apiKey):
+    def __init__(self, domain: str, apiKey: str):
         super().__init__(domain, apiKey)
         self.cases       = CaseAPI(domain, apiKey)
         self.teams       = TeamsAPI(domain, apiKey)

--- a/tapi/client/client.py
+++ b/tapi/client/client.py
@@ -1,7 +1,7 @@
 from tapi.utils.types import HTTPResponse
-from typing           import Optional, Union, Dict, Any
+from json             import JSONDecodeError
+from typing           import Union, Dict, Any
 from requests         import request, RequestException, Response
-
 
 class Client:
     verify_ssl: bool = True
@@ -43,7 +43,10 @@ class Client:
         content_type = response.headers.get("Content-Type", "")
 
         if "application/json" in content_type:
-            body = response.json()
+            try:
+                body = response.json()
+            except JSONDecodeError:
+                body = response.text
         elif "application/pdf" in content_type:
             body = response.content
         else:

--- a/tapi/utils/testing_decorators.py
+++ b/tapi/utils/testing_decorators.py
@@ -1,0 +1,5 @@
+from os       import getenv
+from unittest import skipIf
+
+def premium_feature(func):
+    return skipIf(getenv("SKIP_PREMIUM_TESTS") == "1", "Skipping premium test")(func)

--- a/tapi/utils/types.py
+++ b/tapi/utils/types.py
@@ -1,5 +1,5 @@
 from enum   import IntEnum, StrEnum
-from typing import TypedDict, Union, Dict, Any
+from typing import TypedDict, Union, Dict, Any, Literal, Optional
 
 
 class KeepEventsFor(IntEnum):
@@ -50,12 +50,12 @@ class StoriesReturnOrder(StrEnum):
     LEAST_RECENTLY_EDITED = "LEAST_RECENTLY_EDITED"
 
 class Mode(StrEnum):
-    NEW = "new"
+    NEW             = "new"
     VERSION_REPLACE = "versionReplace"
 
 class Role(StrEnum):
-    VIEWER = "VIEWER"
-    EDITOR = "EDITOR"
+    VIEWER     = "VIEWER"
+    EDITOR     = "EDITOR"
     TEAM_ADMIN = "TEAM_ADMIN"
 
 class CasePriority(StrEnum):
@@ -129,7 +129,7 @@ class AgentType(StrEnum):
     EMAIL           = "Agents::EmailAgent"
     GROUP           = "Agents::GroupAgent"
     TRIGGER         = "Agents::TriggerAgent"
-    WEBHOOK        = "Agents::WebhookAgent"
+    WEBHOOK         = "Agents::WebhookAgent"
     HTTP_REQUEST    = "Agents::HTTPRequestAgent"
     SEND_T0_STORY   = "Agents::SendToStoryAgent"
     EVENT_TRANSFORM = "Agents::EventTransformationAgent"
@@ -278,3 +278,18 @@ class AuditLogType(StrEnum):
     TEAM_CASES_SAVED_VIEW_DESTRUCTION    = "TeamCasesSavedViewDestruction"
     RECORD_REPORT_ELEMENT_DESTRUCTION    = "RecordReportElementDestruction"
     RECORD_REPORT_ELEMENT_COLUMN_REORDER = "RecordReportElementColumnReorder"
+
+class RecordFieldValue(TypedDict):
+    field_id: Union[str, int]
+    value:    Union[Any]
+
+class RecordFilter(TypedDict):
+    field_id: Union[str, int]
+    operator: Union[Literal[
+        "EQUAL", "NOT_EQUAL", "GREATER_THAN",
+        "GREATER_THAN_OR_EQUAL_TO", "LESS_THAN",
+        "LESS_THAN_OR_EQUAL_TO", "IS_EMPTY",
+        "IS_NOT_EMPTY", "IS_TRUE", "IS_FALSE"],
+        str
+    ]
+    value: Optional[Union[str, int]]

--- a/tests/test_api/test_action/test_actions.py
+++ b/tests/test_api/test_action/test_actions.py
@@ -4,10 +4,16 @@ from time             import time_ns
 from tapi.utils.types import AgentType
 from tapi             import ActionsAPI
 from dotenv           import load_dotenv
+from tapi.utils.http  import disable_ssl_verification
+
 
 class test_ActionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.story_id    = int(getenv("ACTION_STORY_ID"))
         self.action_id   = int(getenv("ACTION_ID"))
         self.actions_api = ActionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -43,8 +49,6 @@ class test_ActionsAPI(unittest.TestCase):
 
     def test_update(self):
         rng = time_ns() // 1000
-
-
         resp = self.actions_api.update(
             action_id   = self.action_id,
             description = f"Updated description: {rng}"

--- a/tests/test_api/test_action/test_events.py
+++ b/tests/test_api/test_action/test_events.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ActionEventsAPI
+from os              import getenv
+from dotenv          import load_dotenv
+from tapi            import ActionEventsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_ActionEventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.action_id   = int(getenv("ACTION_ID"))
         self.action_events_api = ActionEventsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_action/test_logs.py
+++ b/tests/test_api/test_action/test_logs.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ActionLogsAPI
+from os              import getenv
+from dotenv          import load_dotenv
+from tapi            import ActionLogsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_ActionLogsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.action_id   = int(getenv("ACTION_ID"))
         self.action_logs_api = ActionLogsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_audit_log/test_audit_logs.py
+++ b/tests/test_api/test_audit_log/test_audit_logs.py
@@ -1,14 +1,21 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi             import AuditLogsAPI
-from tapi.utils.types import AuditLogType
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import AuditLogsAPI
+from tapi.utils.types              import AuditLogType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 class test_AuditLogsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.audt_logs_api = AuditLogsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_list(self):
         resp = self.audt_logs_api.list(
             operation_name = [

--- a/tests/test_api/test_case/test_actions.py
+++ b/tests/test_api/test_case/test_actions.py
@@ -1,13 +1,20 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi             import CaseActionsAPI
-from tapi.utils.types import CaseActionType
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseActionsAPI
+from tapi.utils.types              import CaseActionType
+from tapi.utils.http               import disable_ssl_verification
+
 
 
 class test_CaseActionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.action_id       = None
         self.case_action_api = CaseActionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -19,6 +26,7 @@ class test_CaseActionsAPI(unittest.TestCase):
                 id      = self.action_id
             )
 
+    @premium_feature
     def test_create(self):
         resp = self.case_action_api.create(
             case_id     = self.case_id,
@@ -36,6 +44,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
+    @premium_feature
     def test_get(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -60,6 +69,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("action_type"), CaseActionType.PAGE)
         self.assertEqual(body.get("action_text"), "Open")
 
+    @premium_feature
     def test_update(self):
         action = self.case_action_api.create(
             case_id=self.case_id,
@@ -85,6 +95,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(body.get("label"), "New Updated Action Unit Test")
         self.assertEqual(body.get("action_text"), "GoTo")
 
+    @premium_feature
     def test_list(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -106,6 +117,7 @@ class test_CaseActionsAPI(unittest.TestCase):
         self.assertEqual(type(body.get("actions")), list)
         self.assertGreaterEqual(len(body.get("actions")), 1)
 
+    @premium_feature
     def test_delete(self):
         action = self.case_action_api.create(
             case_id     = self.case_id,
@@ -124,6 +136,7 @@ class test_CaseActionsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_feature
     def tests_batch_update(self):
         actions = [
             {

--- a/tests/test_api/test_case/test_activities.py
+++ b/tests/test_api/test_case/test_activities.py
@@ -1,15 +1,22 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseActivitiesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseActivitiesAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseActivitiesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.case_activities_api = CaseActivitiesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_get(self):
         resp = self.case_activities_api.get(
             case_id = self.case_id,
@@ -18,6 +25,7 @@ class test_CaseActivitiesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
+    @premium_feature
     def test_list(self):
         resp = self.case_activities_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_assignees.py
+++ b/tests/test_api/test_case/test_assignees.py
@@ -1,15 +1,22 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseAssigneesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseAssigneesAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseAssigneesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id            = int(getenv("CASE_ID"))
         self.case_assignees_api = CaseAssigneesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_list(self):
         resp = self.case_assignees_api.list(
             case_id = self.case_id

--- a/tests/test_api/test_case/test_cases.py
+++ b/tests/test_api/test_case/test_cases.py
@@ -14,7 +14,7 @@ class test_CasesAPI(unittest.TestCase):
         if getenv("SSL_VERIFICATION") == "0":
             disable_ssl_verification()
 
-        self.team_id   = 1 #int(getenv("TEAM_ID"))
+        self.team_id   = int(getenv("TEAM_ID"))
         self.case_id   = None
         self.cases_api = CaseAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_case/test_cases.py
+++ b/tests/test_api/test_case/test_cases.py
@@ -1,14 +1,20 @@
 import unittest
-from os               import getenv
-from tapi             import CaseAPI
-from dotenv           import load_dotenv
-from tapi.utils.types import CasePriority, CaseStatus
+from os                            import getenv
+from tapi                          import CaseAPI
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+from tapi.utils.types              import CasePriority, CaseStatus
 
 
 class test_CasesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
-        self.team_id   = int(getenv("TEAM_ID"))
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
+        self.team_id   = 1 #int(getenv("TEAM_ID"))
         self.case_id   = None
         self.cases_api = CaseAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
@@ -16,6 +22,7 @@ class test_CasesAPI(unittest.TestCase):
         if self.case_id:
             self.cases_api.delete(self.case_id)
 
+    @premium_feature
     def test_create(self):
         resp = self.cases_api.create(
             team_id     = self.team_id,
@@ -32,6 +39,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("status"), CaseStatus.OPEN)
         self.assertEqual(body.get("priority"), CasePriority.LOW)
 
+    @premium_feature
     def test_get(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -52,6 +60,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("name"), "Get Case Unit test")
         self.assertEqual(body.get("description"), "Created with Tapi :)")
 
+    @premium_feature
     def test_download(self):
         resp = self.cases_api.download(
             case_id = 26
@@ -62,6 +71,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body), bytes)
 
+    @premium_feature
     def test_update(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -84,6 +94,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertEqual(body.get("description"), "Created with Tapi :) :)")
         self.assertEqual(body.get("priority"), CasePriority.HIGH)
 
+    @premium_feature
     def test_list(self):
         case = self.cases_api.create(
             team_id     = self.team_id,
@@ -102,6 +113,7 @@ class test_CasesAPI(unittest.TestCase):
         self.assertGreaterEqual(len(body.get("cases")), 1)
         self.assertLessEqual(len(body.get("cases")), 5)
 
+    @premium_feature
     def test_delete(self):
         case = self.cases_api.create(
             team_id     = self.team_id,

--- a/tests/test_api/test_case/test_comments.py
+++ b/tests/test_api/test_case/test_comments.py
@@ -1,16 +1,23 @@
 import unittest
-from os               import getenv
-from dotenv           import load_dotenv
-from tapi.utils.types import ReactionType
-from tapi             import CaseCommentsAPI, CaseCommentsReactionsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.types              import ReactionType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+from tapi                          import CaseCommentsAPI, CaseCommentsReactionsAPI
 
 
 class test_CaseCommentsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_comments_api = CaseCommentsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.case_comments_api.create(
             case_id = self.case_id,
@@ -19,6 +26,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_feature
     def test_get(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -38,6 +46,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "Get Comment Unit Test")
 
+    @premium_feature
     def test_update(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -58,6 +67,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(body.get("id"), comment_id)
         self.assertEqual(body.get("value"), "New Updated Comment Unit Test")
 
+    @premium_feature
     def test_list(self):
         resp = self.case_comments_api.list(
             case_id = self.case_id
@@ -68,6 +78,7 @@ class test_CaseCommentsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("comments")), list)
 
+    @premium_feature
     def test_delete(self):
         comment = self.case_comments_api.create(
             case_id = self.case_id,
@@ -89,6 +100,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.case_id                     = int(getenv("CASE_ID"))
         self.case_comments_reactions_api = CaseCommentsReactionsAPI(getenv("DOMAIN"), getenv("API_KEY_2"))
 
+    @premium_feature
     def test_add(self):
         resp = self.case_comments_reactions_api.add(
             case_id    = self.case_id,
@@ -101,6 +113,7 @@ class test_CaseCommentsReactionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(type(body.get("reactions")), list)
 
+    @premium_feature
     def test_remove(self):
         reaction = self.case_comments_reactions_api.add(
             case_id=self.case_id,

--- a/tests/test_api/test_case/test_fields.py
+++ b/tests/test_api/test_case/test_fields.py
@@ -1,16 +1,23 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseFieldsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseFieldsAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFieldsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id         = int(getenv("CASE_ID"))
         self.input_id        = int(getenv("CASE_INPUT_ID"))
         self.case_fields_api = CaseFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.case_fields_api.create(
             case_id  = self.case_id,
@@ -23,6 +30,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(body.get("field").get("value"), "1")
 
+    @premium_feature
     def test_get(self):
         resp = self.case_fields_api.get(
             case_id  = self.case_id,
@@ -35,6 +43,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(body.get("case_id"), self.case_id)
         self.assertEqual(body.get("field").get("id"), int(getenv("CASE_FIELD_ID")))
 
+    @premium_feature
     def test_update(self):
         resp = self.case_fields_api.update(
             case_id  = self.case_id,
@@ -47,6 +56,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("field").get("value"), "2")
 
+    @premium_feature
     def test_list(self):
         resp = self.case_fields_api.list(
             case_id = self.case_id
@@ -57,6 +67,7 @@ class test_CaseFieldsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("fields")), list)
 
+    @premium_feature
     def test_delete(self):
         field = self.case_fields_api.create(
             case_id  = self.case_id,

--- a/tests/test_api/test_case/test_files.py
+++ b/tests/test_api/test_case/test_files.py
@@ -1,15 +1,22 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseFilesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import CaseFilesAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id        = int(getenv("CASE_ID"))
         self.case_files_api = CaseFilesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.case_files_api.create(
             case_id       = self.case_id,
@@ -25,6 +32,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test.txt")
 
+    @premium_feature
     def test_get(self):
         resp = self.case_files_api.get(
             case_id = self.case_id,
@@ -39,6 +47,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("value"), "Testing comment")
         self.assertEqual(body.get("file").get("filename"), "Create File Unit Test")
 
+    @premium_feature
     def test_list(self):
         resp = self.case_files_api.list(
             case_id=self.case_id
@@ -49,6 +58,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("files")), list)
 
+    @premium_feature
     def test_delete(self):
         file = self.case_files_api.create(
             case_id       = self.case_id,
@@ -66,6 +76,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    # @premium_feature
     # Endpoint need to be fixed by Tines, first
     # def test_download(self):
     #     resp = self.case_files_api.download(

--- a/tests/test_api/test_case/test_inputs.py
+++ b/tests/test_api/test_case/test_inputs.py
@@ -1,17 +1,24 @@
 import unittest
-from os               import getenv
-from time             import time_ns
-from dotenv           import load_dotenv
-from tapi.utils.types import CaseInputType
-from tapi             import CaseInputsAPI, CaseInputsFieldsAPI
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
+from tapi.utils.types              import CaseInputType
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+from tapi                          import CaseInputsAPI, CaseInputsFieldsAPI
 
 
 class test_CaseInputsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id         = int(getenv("TEAM_ID"))
         self.case_inputs_api = CaseInputsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         input_id = time_ns() // 1000
         resp = self.case_inputs_api.create(
@@ -25,6 +32,7 @@ class test_CaseInputsAPI(unittest.TestCase):
         self.assertEqual(body.get("team_case_input").get("name"), f"Create Case Input Unit Test {input_id}")
         self.assertEqual(body.get("team_case_input").get("input_type"), CaseInputType.NUMBER)
 
+    @premium_feature
     def test_get(self):
         resp = self.case_inputs_api.get(
             case_input_id = int(getenv("CASE_INPUT_ID"))
@@ -32,6 +40,7 @@ class test_CaseInputsAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 200)
 
+    @premium_feature
     def test_list(self):
         resp = self.case_inputs_api.list(
             team_id = self.team_id
@@ -47,6 +56,7 @@ class test_CaseInputsFieldsAPI(unittest.TestCase):
         load_dotenv()
         self.case_inputs_fields_api = CaseInputsFieldsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_list(self):
         resp = self.case_inputs_fields_api.list(
             case_input_id = int(getenv("CASE_INPUT_ID"))

--- a/tests/test_api/test_case/test_linked_cases.py
+++ b/tests/test_api/test_case/test_linked_cases.py
@@ -1,17 +1,24 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import LinkedCasesAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import LinkedCasesAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_LinkedCasesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_to_link_id_1 = int(getenv("CASE_TO_LINK_ID_1"))
         self.case_to_link_id_2 = int(getenv("CASE_TO_LINK_ID_2"))
         self.linked_cases_api = LinkedCasesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.linked_cases_api.create(
             case_id = self.case_id,
@@ -20,6 +27,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_feature
     def test_list(self):
         resp = self.linked_cases_api.list(
             case_id = self.case_id
@@ -30,6 +38,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("linked_cases")), list)
 
+    @premium_feature
     def test_delete(self):
         resp = self.linked_cases_api.delete(
             case_id = self.case_id,
@@ -38,6 +47,7 @@ class test_LinkedCasesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_feature
     def test_batch_delete(self):
         ids = [
             self.case_to_link_id_1,

--- a/tests/test_api/test_case/test_metadata.py
+++ b/tests/test_api/test_case/test_metadata.py
@@ -1,16 +1,23 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from dotenv import load_dotenv
-from tapi   import CaseMetadataAPI
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseMetadataAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseMetadataAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.case_metadata_api = CaseMetadataAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         rng = time_ns() // 1000
         resp = self.case_metadata_api.create(
@@ -20,6 +27,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_feature
     def test_get(self):
         resp = self.case_metadata_api.get(
             case_id = self.case_id,
@@ -31,6 +39,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertIsNotNone(body.get("metadata").get("test"))
 
+    @premium_feature
     def test_update(self):
         resp = self.case_metadata_api.update(
             case_id  = self.case_id,
@@ -42,6 +51,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("metadata").get("name"), "New Value Unit Test")
 
+    @premium_feature
     def test_list(self):
         resp = self.case_metadata_api.list(
             case_id = self.case_id
@@ -52,6 +62,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("metadata")), dict)
 
+    @premium_feature
     def test_delete(self):
         self.case_metadata_api.create(case_id = self.case_id, metadata={"to_delete": "delete me plz"})
 

--- a/tests/test_api/test_case/test_notes.py
+++ b/tests/test_api/test_case/test_notes.py
@@ -1,19 +1,26 @@
 import unittest
-from os               import getenv
-from time             import time_ns
-from dotenv           import load_dotenv
-from tapi             import CaseNotesAPI
-from tapi.utils.types import CaseNoteColor
+from os                            import getenv
+from time                          import time_ns
+from dotenv                        import load_dotenv
+from tapi                          import CaseNotesAPI
+from tapi.utils.types              import CaseNoteColor
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseMetadataAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id           = int(getenv("CASE_ID"))
         self.note_to_get_id    = int(getenv("CASE_NOTE_TO_GET"))
         self.note_to_update_id = int(getenv("CASE_NOTE_TO_UPDATE"))
         self.case_notes_api    = CaseNotesAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     @unittest.skip("Hitting cap limit")
     def test_create(self):
         resp = self.case_notes_api.create(
@@ -30,6 +37,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("content"), "This is a comment created with Tapi :)")
         self.assertEqual(body.get("color"), CaseNoteColor.BLUE)
 
+    @premium_feature
     def test_get(self):
         resp = self.case_notes_api.get(
             case_id = self.case_id,
@@ -41,6 +49,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(body.get("title"), "Note to Get")
 
+    @premium_feature
     def test_update(self):
         update_time = time_ns() // 1000
 
@@ -59,6 +68,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(body.get("color"), CaseNoteColor.MAGENTA)
         self.assertEqual(body.get("content"), f"This content has been updated at: {update_time}")
 
+    @premium_feature
     def test_list(self):
         resp = self.case_notes_api.list(
             case_id = self.case_id
@@ -69,6 +79,7 @@ class test_CaseMetadataAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("notes")), list)
 
+    @premium_feature
     @unittest.skip("Function runs fine but apparently there is a limit on how much metadata a case can have")
     def test_delete(self):
         note = self.case_notes_api.create(

--- a/tests/test_api/test_case/test_records.py
+++ b/tests/test_api/test_case/test_records.py
@@ -1,17 +1,24 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseRecordsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import CaseRecordsAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id          = int(getenv("CASE_ID"))
         self.record_id        = int(getenv("CASE_RECORD_ID"))
         self.delete_record_id = int(getenv("CASE_DELETE_RECORD_ID"))
         self.case_records_api = CaseRecordsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.case_records_api.create(
             case_id   = self.case_id,
@@ -20,6 +27,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_feature
     def test_get(self):
         resp = self.case_records_api.get(
             case_id   = self.case_id,
@@ -32,6 +40,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(body.get("record").get("id"), self.record_id)
         self.assertEqual(body.get("record").get("record_type"), {"id": 1419, "name": "Record Unit Test"})
 
+    @premium_feature
     def test_list(self):
         resp = self.case_records_api.list(
             case_id = self.case_id
@@ -42,6 +51,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("records")), list)
 
+    @premium_feature
     def test_delete(self):
         record = self.case_records_api.create(
             case_id   = self.case_id,

--- a/tests/test_api/test_case/test_subscribers.py
+++ b/tests/test_api/test_case/test_subscribers.py
@@ -1,16 +1,23 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CaseSubscribersAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import CaseSubscribersAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_CaseFilesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.case_id              = int(getenv("CASE_ID"))
         self.case_sub_email       = getenv("CASE_SUBSCRIBER_EMAIL")
         self.case_subscribers_api = CaseSubscribersAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @premium_feature
     def test_create(self):
         resp = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -19,6 +26,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 201)
 
+    @premium_feature
     def test_list(self):
         resp = self.case_subscribers_api.list(
             case_id = self.case_id
@@ -29,6 +37,7 @@ class test_CaseFilesAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("subscribers")), list)
 
+    @premium_feature
     def test_delete(self):
         subscriber = self.case_subscribers_api.create(
             case_id    = self.case_id,
@@ -44,6 +53,7 @@ class test_CaseFilesAPI(unittest.TestCase):
 
         self.assertEqual(resp.get("status_code"), 204)
 
+    @premium_feature
     def test_batch_create(self):
         resp = self.case_subscribers_api.batch_create(
             case_id = self.case_id,

--- a/tests/test_api/test_credential/test_credentials.py
+++ b/tests/test_api/test_credential/test_credentials.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import CredentialsAPI
-from time   import time_ns
+from os              import getenv
+from time            import time_ns
+from dotenv          import load_dotenv
+from tapi            import CredentialsAPI
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_CredentialsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_cred       = None
         self.cred_id         = int(getenv("CREDENTIAL_ID"))
         self.team_id         = int(getenv("TEAM_ID"))

--- a/tests/test_api/test_event/test_events.py
+++ b/tests/test_api/test_event/test_events.py
@@ -10,6 +10,7 @@ class test_EventsAPI(unittest.TestCase):
         self.event_action_id = int(getenv("EVENT_ACTION_ID"))
         self.events_api      = EventsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
+    @unittest.skip("I need to replace this every 7 days with a new event ID")
     def test_get(self):
         resp = self.events_api.get(
             event_id = self.event_id
@@ -29,6 +30,7 @@ class test_EventsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(type(body.get("events")), list)
 
+    @unittest.skip("This needs to have a valid event id, which needs to be created manually")
     def test_re_emit(self):
         resp = self.events_api.re_emit(
             event_id = self.event_id

--- a/tests/test_api/test_event/test_events.py
+++ b/tests/test_api/test_event/test_events.py
@@ -1,11 +1,17 @@
 import unittest
-from os     import getenv
-from tapi   import EventsAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import EventsAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_EventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.event_id        = int(getenv("EVENT_ID"))
         self.event_action_id = int(getenv("EVENT_ACTION_ID"))
         self.events_api      = EventsAPI(getenv("DOMAIN"), getenv("API_KEY"))

--- a/tests/test_api/test_folder/test_folders.py
+++ b/tests/test_api/test_folder/test_folders.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from tapi   import FoldersAPI
-from dotenv import load_dotenv
+from os              import getenv
+from time            import time_ns
+from tapi            import FoldersAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
+
 
 class test_EventsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_folder_id = None
         self.folder_id      = int(getenv("FOLDER_ID"))
         self.team_id        = int(getenv("TEAM_ID"))
@@ -75,7 +81,7 @@ class test_EventsAPI(unittest.TestCase):
 
     def test_delete(self):
         folder = self.folders_api.create(
-            name         = f"To Delete",
+            name         = "To Delete",
             content_type = "STORY",
             team_id      = self.team_id
         )

--- a/tests/test_api/test_folder/test_folders.py
+++ b/tests/test_api/test_folder/test_folders.py
@@ -42,7 +42,6 @@ class test_EventsAPI(unittest.TestCase):
         self.assertEqual(body.get("name"), "WDWWT")
         self.assertEqual(body.get("content_type"), "STORY")
         self.assertEqual(body.get("team_id"), self.team_id)
-        self.assertEqual(body.get("size"), 0)
 
     def test_update(self):
         rng = time_ns() // 1000

--- a/tests/test_api/test_note/test_notes.py
+++ b/tests/test_api/test_note/test_notes.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from random import randint
-from tapi   import NotesAPI
-from dotenv import load_dotenv
+from os              import getenv
+from random          import randint
+from tapi            import NotesAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_NotesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.note_id   = int(getenv("NOTE_ID"))
         self.story_id  = int(getenv("NOTE_STORY_ID"))
         self.notes_api = NotesAPI(getenv("DOMAIN"), getenv("API_KEY"))

--- a/tests/test_api/test_record/test_records.py
+++ b/tests/test_api/test_record/test_records.py
@@ -7,7 +7,7 @@ from tapi.utils.testing_decorators import premium_feature
 from tapi.utils.http               import disable_ssl_verification
 
 
-class test_NotesAPI(unittest.TestCase):
+class test_RecordsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
 

--- a/tests/test_api/test_record/test_records.py
+++ b/tests/test_api/test_record/test_records.py
@@ -1,0 +1,117 @@
+import unittest
+from os                            import getenv
+from time                          import time_ns
+from tapi                          import RecordsAPI
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+
+
+class test_NotesAPI(unittest.TestCase):
+    def setUp(self):
+        load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
+        self._del_rec_id     = None
+        self.record_id       = int(getenv("RECORD_ID"))
+        self.record_field_id = getenv("RECORD_FIELD_ID")
+        self.record_type_id  = int(getenv("RECORD_TYPE_ID"))
+        self.update_rec_id   = int(getenv("UPDATE_RECORD_ID"))
+        self.records_api     = RecordsAPI(getenv("DOMAIN"), getenv("API_KEY"))
+
+    def tearDown(self):
+        if self._del_rec_id:
+            self.records_api.delete(record_id=self._del_rec_id)
+
+    @premium_feature
+    def test_create(self):
+        resp = self.records_api.create(
+            record_type_id = self.record_type_id,
+            field_values   = [
+                {"field_id": self.record_field_id, "value": "Test value"}
+            ]
+        )
+
+        body = resp.get("body")
+        self._del_rec_id = body.get("id")
+
+        self.assertEqual(resp.get("status_code"), 201)
+        self.assertEqual(body.get("record_type"), {"id": 1419, "name": "Record Unit Test"})
+        self.assertEqual(body.get("case_ids"), [])
+        self.assertEqual(body.get("test_mode"), False)
+
+    @premium_feature
+    def test_get(self):
+        resp = self.records_api.get(
+            record_id = self.record_id
+        )
+
+        body = resp.get("body")
+
+        self.assertEqual(resp.get("status_code"), 200)
+        self.assertEqual(body.get("id"), self.record_id)
+        self.assertEqual(body.get("created_at"), "2025-02-02T22:51:16Z")
+        self.assertEqual(body.get("updated_at"), "2025-02-02T22:51:16Z")
+        self.assertEqual(body.get("story"), None)
+        self.assertEqual(body.get("story_run_guid"), None)
+        self.assertEqual(body.get("record_type"), {"id": 1419, "name": "Record Unit Test"})
+        self.assertEqual(body.get("records"), [
+            {"name": "TestFor", "value": "Case Record 1"},
+            {"name": "Timestamp", "value": "2025-02-02 22:51:16"},
+            {"name": "Story name", "value": None}
+        ])
+        self.assertEqual(body.get("parent_id"), None)
+        self.assertEqual(body.get("child_record_ids"), [])
+        self.assertEqual(body.get("case_ids"), [26])
+        self.assertEqual(body.get("parent_record_result_set"), {"id": None})
+        self.assertEqual(body.get("parent_record"), {"id": None})
+        self.assertEqual(body.get("child_record_result_sets"), [])
+        self.assertEqual(body.get("child_records"), [])
+        self.assertEqual(body.get("record_artifacts"), [])
+        self.assertEqual(body.get("result"), {
+            "TestFor": "Case Record 1",
+            "Timestamp": "2025-02-02 22:51:16",
+            "Story name": None
+        })
+
+    @premium_feature
+    def test_list(self):
+        resp = self.records_api.list(
+            record_type_id = self.record_type_id
+        )
+
+        body = resp.get("body")
+
+        self.assertEqual(resp.get("status_code"), 200)
+        self.assertEqual(type(body.get("record_results")), list)
+        self.assertEqual(len(body.get("record_results")), 2)
+
+    @premium_feature
+    def test_update(self):
+        rng = time_ns() // 1000
+        resp = self.records_api.update(
+            record_id    = self.update_rec_id,
+            field_values = [
+                {"field_id": self.record_field_id, "value": f"Updated value: {rng}"}
+            ]
+        )
+
+        body = resp.get("body")
+
+        self.assertEqual(resp.get("status_code"), 200)
+        self.assertIn({"field_id": "3205", "name": "TestFor", "value": f"Updated value: {rng}"}, body.get("records"))
+
+    @premium_feature
+    def test_delete(self):
+        rec = self.records_api.create(
+            record_type_id = self.record_type_id,
+            field_values   = [
+                {"field_id": self.record_field_id, "value": "Test value"}
+            ]
+        )
+        rec_id = rec.get("body").get("id")
+        resp = self.records_api.delete(record_id=rec_id)
+
+        self.assertEqual(resp.get("status_code"), 204)

--- a/tests/test_api/test_record/test_types.py
+++ b/tests/test_api/test_record/test_types.py
@@ -1,0 +1,109 @@
+import unittest
+from os                            import getenv
+from time                          import time_ns
+from tapi                          import RecordTypesAPI
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+
+
+class test_RecordTypesAPI(unittest.TestCase):
+    def setUp(self):
+        load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
+        self._del_rec_t_id    = None
+        self.team_id          = int(getenv("TEAM_ID"))
+        self.record_type_id   = int(getenv("RECORD_TYPE_ID"))
+        self.record_types_api = RecordTypesAPI(getenv("DOMAIN"), getenv("API_KEY"))
+
+    def tearDown(self):
+        if self._del_rec_t_id:
+            self.record_types_api.delete(record_type_id = self._del_rec_t_id)
+
+    @premium_feature
+    def test_create(self):
+        resp = self.record_types_api.create(
+            name     = "Unit Test Type",
+            team_id  = self.team_id,
+            fields   = [
+                {"name": "Column", "result_type": "TEXT"}
+            ],
+            editable = True
+        )
+
+        body = resp.get("body")
+        self._del_rec_t_id = body.get("id")
+
+        self.assertEqual(resp.get("status_code"), 201)
+        self.assertEqual(body.get("name"), "Unit Test Type")
+        self.assertEqual(body.get("editable"), True)
+        self.assertEqual(body.get("ttl"), None)
+        self.assertEqual(body.get("team_id"), self.team_id)
+
+    @premium_feature
+    def test_get(self):
+        resp = self.record_types_api.get(
+            record_type_id = self.record_type_id
+        )
+
+        body = resp.get("body")
+        self.assertEqual(body, {
+            "id": self.record_type_id,
+            "name": "Record Unit Test",
+            "editable": True,
+            "ttl_days": None,
+            "team_id": self.team_id,
+            "record_fields": [
+                {
+                    "id": 3205,
+                    "name": "TestFor",
+                    "result_type": "TEXT",
+                    "fixed_values": []
+                }
+            ],
+            "default_record_fields": [
+                {
+                    "id": 3203,
+                    "name": "Story name",
+                    "result_type": "TEXT",
+                    "fixed_values": []
+                },
+                {
+                    "id": 3204,
+                    "name": "Timestamp",
+                    "result_type": "TIMESTAMP",
+                    "fixed_values": []
+                }
+            ]
+        }
+    )
+
+    @premium_feature
+    def test_list(self):
+        resp = self.record_types_api.list(
+            team_id = self.team_id
+        )
+
+        body = resp.get("body")
+        self.assertEqual(resp.get("status_code"), 200)
+        self.assertEqual(type(body.get("record_types")), list)
+
+    @premium_feature
+    def test_delete(self):
+        rec_type = self.record_types_api.create(
+            name     = "Unit Test Type",
+            team_id  = self.team_id,
+            fields   = [
+                {"name": "Column", "result_type": "TEXT"}
+            ],
+            editable = True
+        )
+
+        rec_id = rec_type.get("body").get("id")
+
+        resp = self.record_types_api.delete(record_type_id=rec_id)
+
+        self.assertEqual(resp.get("status_code"), 204)

--- a/tests/test_api/test_resource/test_resources.py
+++ b/tests/test_api/test_resource/test_resources.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from time   import time_ns
-from dotenv import load_dotenv
-from tapi   import ResourcesAPI
+from os              import getenv
+from time            import time_ns
+from dotenv          import load_dotenv
+from tapi            import ResourcesAPI
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_ResourcesAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self._del_resource_id   = None
         self.team_id            = int(getenv("TEAM_ID"))
         self.resource_id        = int(getenv("RESOURCE_ID"))

--- a/tests/test_api/test_story/test_change_requests.py
+++ b/tests/test_api/test_story/test_change_requests.py
@@ -1,13 +1,19 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import ChangeRequestAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi                          import ChangeRequestAPI
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_ChangeRequestAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id            = getenv("TEAM_ID")
         self.story_id           = int(getenv("CHANGE_REQUEST_STORY_ID"))
         self.change_request_api = ChangeRequestAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -19,6 +25,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
             change_request_id = self.change_request_id
         )
 
+    @premium_feature
     def test_create(self):
         resp = self.change_request_api.create(
             story_id    = self.story_id,
@@ -32,6 +39,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("id")), int)
         self.assertEqual(type(resp.get("body").get("change_request")), dict)
 
+    @premium_feature
     def test_approve(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -53,6 +61,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(resp.get("body").get("change_request").get("status"), "APPROVED")
 
+    @premium_feature
     def test_cancel(self):
         request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -71,6 +80,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("id"))
         self.assertEqual(type(resp.get("body").get("id")), int)
 
+    @premium_feature
     def test_promote(self):
         create_request = self.change_request_api.create(
             story_id    = self.story_id,
@@ -96,6 +106,7 @@ class test_ChangeRequestAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("name"), "Testing")
         self.assertEqual(resp.get("body").get("id"), self.story_id)
 
+    @premium_feature
     def test_view(self):
         resp = self.change_request_api.view(
             story_id = self.story_id

--- a/tests/test_api/test_story/test_runs.py
+++ b/tests/test_api/test_story/test_runs.py
@@ -1,15 +1,20 @@
 import unittest
-from os     import getenv
-from tapi   import RunsAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import RunsAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_RunsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.story_id       = int(getenv("RUNS_API_STORY_ID"))
-        self.runs_api       = RunsAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.story_run_guid = getenv("RUNS_API_STORY_RUN_GUID")
+        self.runs_api       = RunsAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
     def test_events(self):
         resp = self.runs_api.events(

--- a/tests/test_api/test_story/test_stories.py
+++ b/tests/test_api/test_story/test_stories.py
@@ -1,13 +1,18 @@
 import unittest
-from os     import getenv
-from tapi   import StoriesAPI
-from dotenv import load_dotenv
+from os              import getenv
+from tapi            import StoriesAPI
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_StoriesAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.stories_api = StoriesAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.team_id     = int(getenv("TEAM_ID"))
         self.story_id    = None

--- a/tests/test_api/test_story/test_versions.py
+++ b/tests/test_api/test_story/test_versions.py
@@ -1,11 +1,18 @@
 import unittest
-from os     import getenv
-from dotenv import load_dotenv
-from tapi   import VersionsAPI
+from os                            import getenv
+from dotenv                        import load_dotenv
+from tapi                          import VersionsAPI
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
+
 
 class test_VersionsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.version_id   = None
         self.story_id     = int(getenv("VERSIONS_API_STORY_ID"))
         self.versions_api = VersionsAPI(getenv("DOMAIN"), getenv("API_KEY"))
@@ -17,6 +24,7 @@ class test_VersionsAPI(unittest.TestCase):
                 version_id = self.version_id
             )
 
+    @premium_feature
     def test_create(self):
         resp = self.versions_api.create(
             story_id = self.story_id,
@@ -28,6 +36,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"),                           200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "Create Version Unit Test")
 
+    @premium_feature
     def test_get(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -46,6 +55,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertIsNotNone(resp.get("body").get("story_version").get("export_file"))
         self.assertEqual(type(resp.get("body").get("story_version").get("export_file")), dict)
 
+    @premium_feature
     def test_update(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -63,6 +73,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 200)
         self.assertEqual(resp.get("body").get("story_version").get("name"), "New Version Unit Test Name")
 
+    @premium_feature
     def test_list(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,
@@ -79,6 +90,7 @@ class test_VersionsAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("story_versions")), list)
         self.assertGreaterEqual(len(resp.get("body").get("story_versions")), 1)
 
+    @premium_feature
     def test_delete(self):
         create_version = self.versions_api.create(
             story_id = self.story_id,

--- a/tests/test_api/test_team/test_members.py
+++ b/tests/test_api/test_team/test_members.py
@@ -3,11 +3,16 @@ from tapi.utils.types import Role
 from os               import getenv
 from tapi             import MembersAPI
 from dotenv           import load_dotenv
+from tapi.utils.http  import disable_ssl_verification
 
 
 class test_MembersAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.team_id     = int(getenv("TEAM_ID"))
         self.members_api = MembersAPI(getenv("DOMAIN"), getenv("API_KEY"))
 

--- a/tests/test_api/test_team/test_teams.py
+++ b/tests/test_api/test_team/test_teams.py
@@ -1,12 +1,18 @@
 import unittest
-from os     import getenv
-from tapi   import TeamsAPI
-from dotenv import load_dotenv
+from os                            import getenv
+from tapi                          import TeamsAPI
+from dotenv                        import load_dotenv
+from tapi.utils.testing_decorators import premium_feature
+from tapi.utils.http               import disable_ssl_verification
 
 
 class test_TeamsAPI(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.teams_api = TeamsAPI(getenv("DOMAIN"), getenv("API_KEY"))
         self.team_id   = None
 
@@ -16,6 +22,7 @@ class test_TeamsAPI(unittest.TestCase):
                 team_id = self.team_id
             )
 
+    @premium_feature
     def test_create(self):
         resp = self.teams_api.create(
             name = "Create Team Unit Test"
@@ -26,6 +33,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("status_code"), 201)
         self.assertEqual(resp.get("body").get("name"), "Create Team Unit Test")
 
+    @premium_feature
     def test_get(self):
         team = self.teams_api.create(
             name = "Get Team Unit Test"
@@ -42,6 +50,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("name"), "Get Team Unit Test")
         self.assertEqual(type(resp.get("body").get("groups")), list)
 
+    @premium_feature
     def test_update(self):
         team = self.teams_api.create(
             name = "Update Team Unit Test"
@@ -58,6 +67,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(resp.get("body").get("id"), self.team_id)
         self.assertEqual(resp.get("body").get("name"), "New Updated Team Unit Test")
 
+    @premium_feature
     def test_list(self):
         team = self.teams_api.create(
             name = "List Team Unit Test"
@@ -71,6 +81,7 @@ class test_TeamsAPI(unittest.TestCase):
         self.assertEqual(type(resp.get("body").get("teams")), list)
         self.assertGreaterEqual(len(resp.get("body").get("teams")), 1)
 
+    @premium_feature
     def test_delete(self):
         team = self.teams_api.create(
             name="Delete Team Unit Test"

--- a/tests/test_api/test_tenant.py
+++ b/tests/test_api/test_tenant.py
@@ -2,12 +2,17 @@ import unittest
 from os     import getenv
 from tapi   import TenantAPI
 from dotenv import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_TenantAPI(unittest.TestCase):
 
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.tenant_api = TenantAPI(getenv("DOMAIN"), getenv("API_KEY"))
 
     def test_info(self):

--- a/tests/test_client/test_client.py
+++ b/tests/test_client/test_client.py
@@ -1,12 +1,17 @@
 import unittest
-from os          import getenv
-from tapi.client import Client
-from dotenv      import load_dotenv
+from os              import getenv
+from tapi.client     import Client
+from dotenv          import load_dotenv
+from tapi.utils.http import disable_ssl_verification
 
 
 class test_Client(unittest.TestCase):
     def setUp(self):
         load_dotenv()
+
+        if getenv("SSL_VERIFICATION") == "0":
+            disable_ssl_verification()
+
         self.DOMAIN  = getenv("DOMAIN")
         self.API_KEY = getenv("API_KEY")
 
@@ -16,21 +21,21 @@ class test_Client(unittest.TestCase):
 
     def test_http_request_with_good_credentials(self):
         client = Client(self.DOMAIN, self.API_KEY)
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 200)
 
     def test_http_request_with_bad_api_key(self):
         client = Client(self.DOMAIN, "API_KEY")
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 401)
 
     def test_http_request_with_bad_domain(self):
         client = Client("DOMAIN", self.API_KEY)
-        req = client._http_request(method="GET", endpoint="/info")
+        req = client._http_request(method="GET", endpoint="info")
 
         self.assertEqual(type(req), dict)
         self.assertEqual(req["status_code"], 500)


### PR DESCRIPTION
Added support for the following endpoints:

- [Records](https://www.tines.com/api/records/)
- [Record Types](https://www.tines.com/api/records/record_types)
- [Record Arficats](https://www.tines.com/api/records/artifacts)

Others:
- Fixed broken tests
- Added 2 new env vars which can be used to run community compatible tests and paid feature tests. 
  - SKIP_PREMIUM_TESTS=1 -> Skips any paid feature test
  - SKIP_PREMIUM_TESTS=0 -> Runs all available tests
  - SSL_VERIFICATION=1 -> Skips requests SSL verification.
  - SSL_VERIFICATION=0 -> Keeps normal behavior